### PR TITLE
Fix unused import error

### DIFF
--- a/src/data/resume.tsx
+++ b/src/data/resume.tsx
@@ -1,6 +1,5 @@
 import { Icons } from "@/components/icons";
 import { CodeIcon, HomeIcon, NotebookIcon, PencilLine } from "lucide-react";
-import { title } from "process";
 
 export const DATA = {
   name: "Diego Villagran Salazar",


### PR DESCRIPTION
## Summary
- remove unused import from resume data

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af0508470832198995a5034ca69ea