### PR TITLE
Add basic testing setup

### DIFF
--- a/__tests__/useProjectFilter.test.ts
+++ b/__tests__/useProjectFilter.test.ts
@@ -1,0 +1,45 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useProjectFilter } from '@/hooks/useProjectFilter'
+
+jest.mock('@/data/resume', () => ({
+  DATA: {
+    projects: [
+      {
+        title: 'Project A',
+        description: '',
+        dates: '',
+        technologies: ['React', 'Tailwind'],
+        active: true,
+      },
+      {
+        title: 'Project B',
+        description: '',
+        dates: '',
+        technologies: ['Python', 'Data'],
+        active: true,
+      },
+    ],
+  },
+}))
+
+describe('useProjectFilter', () => {
+  it('returns all projects by default', () => {
+    const { result } = renderHook(() => useProjectFilter())
+    expect(result.current.activeFilter).toBe('all')
+    expect(result.current.filteredProjects).toHaveLength(2)
+  })
+
+  it('filters projects by technology', () => {
+    const { result } = renderHook(() => useProjectFilter())
+    act(() => {
+      result.current.setActiveFilter('python')
+    })
+    expect(result.current.filteredProjects).toHaveLength(1)
+    expect(result.current.filteredProjects[0].title).toBe('Project B')
+  })
+
+  it('includes \"all\" as first category', () => {
+    const { result } = renderHook(() => useProjectFilter())
+    expect(result.current.categories[0]).toBe('all')
+  })
+})

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,11 @@
+import { cn } from '@/lib/utils'
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('bg-red-500', 'text-white')).toBe('bg-red-500 text-white')
+  })
+
+  it('resolves tailwind conflicts', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './',
+})
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testEnvironment: 'jsdom',
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@radix-ui/react-aspect-ratio": "^1.1.1",
@@ -49,6 +50,12 @@
     "eslint-config-next": "14.2.4",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/jest-dom": "^6.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- configure Jest for Next.js projects
- add sample tests for the cn utility and useProjectFilter hook

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af60beaa8832190aa4bd079baa0cb