### PR TITLE
Improve

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,7 +9,11 @@
   "orientation": "portrait-primary",
   "scope": "/",
   "lang": "es",
-  "categories": ["business", "productivity", "portfolio"],
+  "categories": [
+    "business",
+    "productivity",
+    "portfolio"
+  ],
   "icons": [
     {
       "src": "/favicon.ico",
@@ -27,22 +31,6 @@
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable any"
-    }
-  ],
-  "screenshots": [
-    {
-      "src": "/screenshot-wide.png",
-      "sizes": "1280x720",
-      "type": "image/png",
-      "form_factor": "wide",
-      "label": "Portfolio Desktop View"
-    },
-    {
-      "src": "/screenshot-narrow.png",
-      "sizes": "640x1136",
-      "type": "image/png",
-      "form_factor": "narrow",
-      "label": "Portfolio Mobile View"
     }
   ],
   "shortcuts": [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ import { ServiceWorkerProvider } from "@/components/service-worker-provider";
 import { I18nProvider } from "@/contexts/i18n-context";
 import { ProfileProvider } from "@/contexts/profile-context";
 import { DATA } from "@/data/resume";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter as FontSans } from "next/font/google";
 import "./globals.css";
 
@@ -19,6 +19,10 @@ const fontSans = FontSans({
   subsets: ["latin"],
   variable: "--font-sans",
 });
+
+export const viewport: Viewport = {
+  themeColor: "#000000",
+};
 
 export const metadata: Metadata = {
   metadataBase: new URL(DATA.url),
@@ -113,13 +117,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="es" suppressHydrationWarning>
-      <head>
-        <meta name="theme-color" content="#000000" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-        <meta name="apple-mobile-web-app-title" content={DATA.name} />
-        <link rel="apple-touch-icon" href="/icon-192.svg" />
-      </head>
       <body
         className={cn(
           "min-h-screen bg-background font-sans antialiased",

--- a/src/components/portfolio/activity-graph.tsx
+++ b/src/components/portfolio/activity-graph.tsx
@@ -55,12 +55,12 @@ export function ActivityGraph({ className }: ActivityGraphProps) {
     }, []);
 
     return (
-        <div className={cn("w-full overflow-hidden rounded-xl border border-white/10 bg-black/20 p-6 backdrop-blur-sm", className)}>
-            <div className="mb-4 flex items-center justify-between">
+        <div className={cn("w-full overflow-hidden rounded-xl border border-white/10 bg-black/20 p-4 sm:p-6 backdrop-blur-sm", className)}>
+            <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <h3 className="text-sm font-semibold uppercase tracking-wider text-white/70">
                     {language === "en" ? "Coding Activity" : "Actividad de Código"}
                 </h3>
-                <div className="flex items-center gap-2 text-xs text-white/40">
+                <div className="flex items-center gap-2 text-xs text-white/40 self-end sm:self-auto">
                     <span>Less</span>
                     <div className="flex gap-1">
                         <div className="h-2.5 w-2.5 rounded-sm bg-white/5" />
@@ -73,36 +73,40 @@ export function ActivityGraph({ className }: ActivityGraphProps) {
                 </div>
             </div>
 
-            <div className="flex w-full gap-1 overflow-x-auto pb-2 scrollbar-hide">
-                {/* We group by weeks for the grid layout */}
-                {Array.from({ length: 52 }).map((_, weekIndex) => (
-                    <div key={weekIndex} className="flex flex-col gap-1">
-                        {Array.from({ length: 7 }).map((_, dayIndex) => {
-                            const dataIndex = weekIndex * 7 + dayIndex;
-                            const dayData = data[dataIndex];
+            <div className="relative">
+                <div className="flex w-full gap-1 overflow-x-auto pb-2 scrollbar-hide mask-linear-fade">
+                    {/* We group by weeks for the grid layout */}
+                    {Array.from({ length: 52 }).map((_, weekIndex) => (
+                        <div key={weekIndex} className="flex flex-col gap-1 min-w-[10px]">
+                            {Array.from({ length: 7 }).map((_, dayIndex) => {
+                                const dataIndex = weekIndex * 7 + dayIndex;
+                                const dayData = data[dataIndex];
 
-                            if (!dayData) return <div key={dayIndex} className="h-2.5 w-2.5" />;
+                                if (!dayData) return <div key={dayIndex} className="h-2.5 w-2.5" />;
 
-                            return (
-                                <motion.div
-                                    key={dayData.date}
-                                    initial={{ opacity: 0, scale: 0 }}
-                                    animate={{ opacity: 1, scale: 1 }}
-                                    transition={{ delay: dataIndex * 0.002 }}
-                                    className={cn(
-                                        "h-2.5 w-2.5 rounded-sm transition-colors hover:ring-1 hover:ring-white/50",
-                                        dayData.intensity === 0 && "bg-white/5",
-                                        dayData.intensity === 1 && "bg-emerald-900/40",
-                                        dayData.intensity === 2 && "bg-emerald-700/60",
-                                        dayData.intensity === 3 && "bg-emerald-500/80",
-                                        dayData.intensity === 4 && "bg-emerald-400"
-                                    )}
-                                    title={`${dayData.date}: ${dayData.count} contributions`}
-                                />
-                            );
-                        })}
-                    </div>
-                ))}
+                                return (
+                                    <motion.div
+                                        key={dayData.date}
+                                        initial={{ opacity: 0, scale: 0 }}
+                                        animate={{ opacity: 1, scale: 1 }}
+                                        transition={{ delay: dataIndex * 0.002 }}
+                                        className={cn(
+                                            "h-2.5 w-2.5 rounded-sm transition-colors hover:ring-1 hover:ring-white/50",
+                                            dayData.intensity === 0 && "bg-white/5",
+                                            dayData.intensity === 1 && "bg-emerald-900/40",
+                                            dayData.intensity === 2 && "bg-emerald-700/60",
+                                            dayData.intensity === 3 && "bg-emerald-500/80",
+                                            dayData.intensity === 4 && "bg-emerald-400"
+                                        )}
+                                        title={`${dayData.date}: ${dayData.count} contributions`}
+                                    />
+                                );
+                            })}
+                        </div>
+                    ))}
+                </div>
+                {/* Fade effect for mobile scroll indication */}
+                <div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-black/20 to-transparent sm:hidden" />
             </div>
         </div>
     );

--- a/src/components/portfolio/activity-graph.tsx
+++ b/src/components/portfolio/activity-graph.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import { useI18n } from "@/contexts/i18n-context";
+import { cn } from "@/lib/utils";
+
+interface ActivityGraphProps {
+    className?: string;
+}
+
+export function ActivityGraph({ className }: ActivityGraphProps) {
+    const { language } = useI18n();
+    const [data, setData] = useState<{ date: string; count: number; intensity: number }[]>([]);
+
+    useEffect(() => {
+        // Generate fake contribution data for the last 365 days
+        const today = new Date();
+        const newData = [];
+        for (let i = 364; i >= 0; i--) {
+            const date = new Date(today);
+            date.setDate(date.getDate() - i);
+
+            // Randomize contribution count with some "clusters" to look realistic
+            const baseRandom = Math.random();
+            let count = 0;
+
+            // Simulate weekends being less active
+            const isWeekend = date.getDay() === 0 || date.getDay() === 6;
+
+            if (baseRandom > 0.7) {
+                count = Math.floor(Math.random() * 5) + 1;
+            } else if (baseRandom > 0.9) {
+                count = Math.floor(Math.random() * 10) + 5;
+            }
+
+            if (isWeekend && Math.random() > 0.3) {
+                count = 0;
+            }
+
+            // Calculate intensity (0-4)
+            let intensity = 0;
+            if (count > 0) intensity = 1;
+            if (count > 3) intensity = 2;
+            if (count > 6) intensity = 3;
+            if (count > 9) intensity = 4;
+
+            newData.push({
+                date: date.toISOString().split('T')[0],
+                count,
+                intensity
+            });
+        }
+        setData(newData);
+    }, []);
+
+    return (
+        <div className={cn("w-full overflow-hidden rounded-xl border border-white/10 bg-black/20 p-6 backdrop-blur-sm", className)}>
+            <div className="mb-4 flex items-center justify-between">
+                <h3 className="text-sm font-semibold uppercase tracking-wider text-white/70">
+                    {language === "en" ? "Coding Activity" : "Actividad de Código"}
+                </h3>
+                <div className="flex items-center gap-2 text-xs text-white/40">
+                    <span>Less</span>
+                    <div className="flex gap-1">
+                        <div className="h-2.5 w-2.5 rounded-sm bg-white/5" />
+                        <div className="h-2.5 w-2.5 rounded-sm bg-emerald-900/40" />
+                        <div className="h-2.5 w-2.5 rounded-sm bg-emerald-700/60" />
+                        <div className="h-2.5 w-2.5 rounded-sm bg-emerald-500/80" />
+                        <div className="h-2.5 w-2.5 rounded-sm bg-emerald-400" />
+                    </div>
+                    <span>More</span>
+                </div>
+            </div>
+
+            <div className="flex w-full gap-1 overflow-x-auto pb-2 scrollbar-hide">
+                {/* We group by weeks for the grid layout */}
+                {Array.from({ length: 52 }).map((_, weekIndex) => (
+                    <div key={weekIndex} className="flex flex-col gap-1">
+                        {Array.from({ length: 7 }).map((_, dayIndex) => {
+                            const dataIndex = weekIndex * 7 + dayIndex;
+                            const dayData = data[dataIndex];
+
+                            if (!dayData) return <div key={dayIndex} className="h-2.5 w-2.5" />;
+
+                            return (
+                                <motion.div
+                                    key={dayData.date}
+                                    initial={{ opacity: 0, scale: 0 }}
+                                    animate={{ opacity: 1, scale: 1 }}
+                                    transition={{ delay: dataIndex * 0.002 }}
+                                    className={cn(
+                                        "h-2.5 w-2.5 rounded-sm transition-colors hover:ring-1 hover:ring-white/50",
+                                        dayData.intensity === 0 && "bg-white/5",
+                                        dayData.intensity === 1 && "bg-emerald-900/40",
+                                        dayData.intensity === 2 && "bg-emerald-700/60",
+                                        dayData.intensity === 3 && "bg-emerald-500/80",
+                                        dayData.intensity === 4 && "bg-emerald-400"
+                                    )}
+                                    title={`${dayData.date}: ${dayData.count} contributions`}
+                                />
+                            );
+                        })}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/portfolio/case-showcase.tsx
+++ b/src/components/portfolio/case-showcase.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { motion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import { PortfolioCaseStudy, resolveText, type LocalizedText } from "@/data/profiles/types";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/contexts/i18n-context";
+import { Code2, X } from "lucide-react";
 
 interface CaseShowcaseProps {
   studies: PortfolioCaseStudy[];
@@ -16,6 +17,7 @@ interface CaseShowcaseProps {
 
 export function CaseShowcase({ studies, onSectionView, onProofClick }: CaseShowcaseProps) {
   const { language } = useI18n();
+  const [activeCode, setActiveCode] = useState<string | null>(null);
 
   const localizedCopy = useMemo(
     () => ({
@@ -46,6 +48,10 @@ export function CaseShowcase({ studies, onSectionView, onProofClick }: CaseShowc
       result: {
         en: "Result",
         es: "Resultado",
+      },
+      viewCode: {
+        en: "View Code",
+        es: "Ver Código",
       },
     }),
     [],
@@ -106,13 +112,63 @@ export function CaseShowcase({ studies, onSectionView, onProofClick }: CaseShowc
               )}
             </div>
 
-            <div className="relative aspect-[16/9] sm:aspect-[16/10] md:aspect-[16/9] w-full overflow-hidden rounded-xl sm:rounded-2xl border border-white/10">
-              <Image
-                src={study.media.src}
-                alt={study.media.alt}
-                fill
-                className="object-cover transition-transform duration-700 group-hover:scale-105"
-              />
+            <div className="relative aspect-[16/9] sm:aspect-[16/10] md:aspect-[16/9] w-full overflow-hidden rounded-xl sm:rounded-2xl border border-white/10 bg-black">
+              <AnimatePresence mode="wait">
+                {activeCode === resolveText(study.title, language) && study.codeSnippet ? (
+                  <motion.div
+                    key="code"
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -10 }}
+                    className="absolute inset-0 z-20 flex flex-col bg-[#0d1117] p-4 text-left font-mono text-xs"
+                  >
+                    <div className="mb-2 flex items-center justify-between border-b border-white/10 pb-2">
+                      <span className="text-white/50">{study.codeSnippet.file}</span>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setActiveCode(null);
+                        }}
+                        className="rounded-full p-1 hover:bg-white/10"
+                      >
+                        <X className="h-4 w-4 text-white/70" />
+                      </button>
+                    </div>
+                    <div className="overflow-auto text-blue-300">
+                      <pre>
+                        <code>{study.codeSnippet.code}</code>
+                      </pre>
+                    </div>
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="image"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    className="relative h-full w-full"
+                  >
+                    <Image
+                      src={study.media.src}
+                      alt={study.media.alt}
+                      fill
+                      className="object-cover transition-transform duration-700 group-hover:scale-105"
+                    />
+                    {study.codeSnippet && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setActiveCode(resolveText(study.title, language));
+                        }}
+                        className="absolute bottom-3 right-3 z-10 flex items-center gap-2 rounded-full bg-black/80 px-3 py-1.5 text-xs font-medium text-white backdrop-blur-md transition-transform hover:scale-105 border border-white/20"
+                      >
+                        <Code2 className="h-3 w-3" />
+                        {resolveText(localizedCopy.viewCode, language)}
+                      </button>
+                    )}
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </div>
 
             <div className="space-y-2 sm:space-y-3">

--- a/src/components/portfolio/case-showcase.tsx
+++ b/src/components/portfolio/case-showcase.tsx
@@ -160,9 +160,9 @@ export function CaseShowcase({ studies, onSectionView, onProofClick }: CaseShowc
                           e.stopPropagation();
                           setActiveCode(resolveText(study.title, language));
                         }}
-                        className="absolute bottom-3 right-3 z-10 flex items-center gap-2 rounded-full bg-black/80 px-3 py-1.5 text-xs font-medium text-white backdrop-blur-md transition-transform hover:scale-105 border border-white/20"
+                        className="absolute bottom-3 right-3 z-10 flex items-center gap-2 rounded-full bg-black/80 px-4 py-2 sm:px-3 sm:py-1.5 text-xs font-medium text-white backdrop-blur-md transition-transform hover:scale-105 border border-white/20 shadow-lg"
                       >
-                        <Code2 className="h-3 w-3" />
+                        <Code2 className="h-4 w-4 sm:h-3 sm:w-3" />
                         {resolveText(localizedCopy.viewCode, language)}
                       </button>
                     )}

--- a/src/components/portfolio/command-menu.tsx
+++ b/src/components/portfolio/command-menu.tsx
@@ -45,7 +45,19 @@ export function CommandMenu() {
         command();
     }, []);
 
-    const groups = [
+    interface CommandItem {
+        icon: any;
+        label: string;
+        action: () => void;
+        active?: boolean;
+    }
+
+    interface CommandGroup {
+        heading: string;
+        items: CommandItem[];
+    }
+
+    const groups: CommandGroup[] = [
         {
             heading: language === "en" ? "Navigation" : "Navegación",
             items: [

--- a/src/components/portfolio/command-menu.tsx
+++ b/src/components/portfolio/command-menu.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { useI18n } from "@/contexts/i18n-context";
+import { useProfile } from "@/contexts/profile-context";
+import {
+    Command,
+    Search,
+    User,
+    Briefcase,
+    Mail,
+    FileText,
+    Languages,
+    Laptop,
+    Database,
+    Server,
+    LineChart,
+    ArrowRight
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ProfileType } from "@/data/profiles/metadata";
+
+export function CommandMenu() {
+    const [open, setOpen] = React.useState(false);
+    const [query, setQuery] = React.useState("");
+    const router = useRouter();
+    const { language, setLanguage } = useI18n();
+    const { setProfile, profile } = useProfile();
+
+    React.useEffect(() => {
+        const down = (e: KeyboardEvent) => {
+            if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                setOpen((open) => !open);
+            }
+        };
+        document.addEventListener("keydown", down);
+        return () => document.removeEventListener("keydown", down);
+    }, []);
+
+    const runCommand = React.useCallback((command: () => void) => {
+        setOpen(false);
+        command();
+    }, []);
+
+    const groups = [
+        {
+            heading: language === "en" ? "Navigation" : "Navegación",
+            items: [
+                {
+                    icon: User,
+                    label: language === "en" ? "Home" : "Inicio",
+                    action: () => router.push("/"),
+                },
+                {
+                    icon: Briefcase,
+                    label: language === "en" ? "Projects" : "Proyectos",
+                    action: () => router.push("/projects"),
+                },
+                {
+                    icon: Mail,
+                    label: language === "en" ? "Contact" : "Contacto",
+                    action: () => {
+                        const contactSection = document.getElementById("contact");
+                        if (contactSection) {
+                            contactSection.scrollIntoView({ behavior: "smooth" });
+                        } else {
+                            router.push("/#contact");
+                        }
+                    },
+                },
+            ],
+        },
+        {
+            heading: language === "en" ? "Switch Profile" : "Cambiar Perfil",
+            items: [
+                {
+                    icon: Laptop,
+                    label: "Machine Learning Engineer",
+                    action: () => {
+                        setProfile("ml-engineer");
+                        router.push("/ml-engineer");
+                    },
+                    active: profile === "ml-engineer",
+                },
+                {
+                    icon: Database,
+                    label: "Data Engineer",
+                    action: () => {
+                        setProfile("data-engineer");
+                        router.push("/data-engineer");
+                    },
+                    active: profile === "data-engineer",
+                },
+                {
+                    icon: Server,
+                    label: "DevOps Engineer",
+                    action: () => {
+                        setProfile("devops-engineer");
+                        router.push("/devops-engineer");
+                    },
+                    active: profile === "devops-engineer",
+                },
+                {
+                    icon: LineChart,
+                    label: "Data Analyst",
+                    action: () => {
+                        setProfile("data-analyst");
+                        router.push("/data-analyst");
+                    },
+                    active: profile === "data-analyst",
+                },
+            ],
+        },
+        {
+            heading: language === "en" ? "Settings" : "Configuración",
+            items: [
+                {
+                    icon: Languages,
+                    label: language === "en" ? "Switch to Spanish" : "Cambiar a Inglés",
+                    action: () => setLanguage(language === "en" ? "es" : "en"),
+                },
+                {
+                    icon: FileText,
+                    label: language === "en" ? "Download Resume" : "Descargar CV",
+                    action: () => {
+                        // Logic to download current profile resume
+                        const link = document.createElement('a');
+                        link.href = `/resumes/diego_villagran_resume_${profile === 'ml-engineer' ? 'ml' : profile === 'data-engineer' ? 'etl' : profile === 'devops-engineer' ? 'devops' : 'analyst'}.pdf`;
+                        link.download = `Diego_Villagran_${profile}_Resume.pdf`;
+                        document.body.appendChild(link);
+                        link.click();
+                        document.body.removeChild(link);
+                    },
+                },
+            ],
+        },
+    ];
+
+    const filteredGroups = groups.map(group => ({
+        ...group,
+        items: group.items.filter(item =>
+            item.label.toLowerCase().includes(query.toLowerCase())
+        )
+    })).filter(group => group.items.length > 0);
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogContent className="overflow-hidden p-0 shadow-2xl sm:max-w-[550px] bg-[#0a0a0a] border-white/10">
+                <div className="flex items-center border-b border-white/10 px-4" cmdk-input-wrapper="">
+                    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50 text-white" />
+                    <input
+                        className="flex h-12 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-white/50 text-white disabled:cursor-not-allowed disabled:opacity-50"
+                        placeholder={language === "en" ? "Type a command or search..." : "Escribe un comando o busca..."}
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        autoFocus
+                    />
+                    <div className="flex items-center gap-1 text-xs text-white/40">
+                        <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border border-white/10 bg-white/5 px-1.5 font-mono font-medium opacity-100">
+                            <span className="text-xs">ESC</span>
+                        </kbd>
+                    </div>
+                </div>
+                <div className="max-h-[300px] overflow-y-auto overflow-x-hidden py-2">
+                    {filteredGroups.length === 0 && (
+                        <div className="py-6 text-center text-sm text-white/50">
+                            {language === "en" ? "No results found." : "No se encontraron resultados."}
+                        </div>
+                    )}
+
+                    {filteredGroups.map((group, i) => (
+                        <div key={group.heading} className="mb-2">
+                            <div className="px-4 py-1.5 text-xs font-medium text-white/40 uppercase tracking-wider">
+                                {group.heading}
+                            </div>
+                            {group.items.map((item, j) => (
+                                <div
+                                    key={item.label}
+                                    onClick={() => runCommand(item.action)}
+                                    className={cn(
+                                        "group mx-2 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-white/80 transition-colors hover:bg-white/10 hover:text-white",
+                                        item.active && "bg-white/10 text-white"
+                                    )}
+                                >
+                                    <item.icon className={cn("h-4 w-4 text-white/50 group-hover:text-white", item.active && "text-white")} />
+                                    <span className="flex-1">{item.label}</span>
+                                    {item.active && <ArrowRight className="h-3 w-3 text-white/50" />}
+                                </div>
+                            ))}
+                        </div>
+                    ))}
+                </div>
+                <div className="border-t border-white/10 px-4 py-2.5 text-xs text-white/40 flex justify-between">
+                    <span>
+                        {language === "en" ? "Pro tip: Use" : "Tip: Usa"} <kbd className="font-sans">↑</kbd> <kbd className="font-sans">↓</kbd> {language === "en" ? "to navigate" : "para navegar"}
+                    </span>
+                    <span>
+                        Portfolio v2.0
+                    </span>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/portfolio/command-menu.tsx
+++ b/src/components/portfolio/command-menu.tsx
@@ -17,10 +17,12 @@ import {
     Database,
     Server,
     LineChart,
-    ArrowRight
+    ArrowRight,
+    Menu
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ProfileType } from "@/data/profiles/metadata";
+import { Button } from "@/components/ui/button";
 
 export function CommandMenu() {
     const [open, setOpen] = React.useState(false);
@@ -44,6 +46,7 @@ export function CommandMenu() {
         setOpen(false);
         command();
     }, []);
+
 
     interface CommandItem {
         icon: any;
@@ -159,61 +162,71 @@ export function CommandMenu() {
     })).filter(group => group.items.length > 0);
 
     return (
-        <Dialog open={open} onOpenChange={setOpen}>
-            <DialogContent className="overflow-hidden p-0 shadow-2xl sm:max-w-[550px] bg-[#0a0a0a] border-white/10">
-                <div className="flex items-center border-b border-white/10 px-4" cmdk-input-wrapper="">
-                    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50 text-white" />
-                    <input
-                        className="flex h-12 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-white/50 text-white disabled:cursor-not-allowed disabled:opacity-50"
-                        placeholder={language === "en" ? "Type a command or search..." : "Escribe un comando o busca..."}
-                        value={query}
-                        onChange={(e) => setQuery(e.target.value)}
-                        autoFocus
-                    />
-                    <div className="flex items-center gap-1 text-xs text-white/40">
-                        <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border border-white/10 bg-white/5 px-1.5 font-mono font-medium opacity-100">
-                            <span className="text-xs">ESC</span>
-                        </kbd>
-                    </div>
-                </div>
-                <div className="max-h-[300px] overflow-y-auto overflow-x-hidden py-2">
-                    {filteredGroups.length === 0 && (
-                        <div className="py-6 text-center text-sm text-white/50">
-                            {language === "en" ? "No results found." : "No se encontraron resultados."}
-                        </div>
-                    )}
+        <>
+            <button
+                onClick={() => setOpen(true)}
+                className="fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-white/10 text-white backdrop-blur-md border border-white/20 shadow-lg transition-transform hover:scale-110 active:scale-95 md:hidden"
+                aria-label="Open command menu"
+            >
+                <Command className="h-6 w-6" />
+            </button>
 
-                    {filteredGroups.map((group, i) => (
-                        <div key={group.heading} className="mb-2">
-                            <div className="px-4 py-1.5 text-xs font-medium text-white/40 uppercase tracking-wider">
-                                {group.heading}
-                            </div>
-                            {group.items.map((item, j) => (
-                                <div
-                                    key={item.label}
-                                    onClick={() => runCommand(item.action)}
-                                    className={cn(
-                                        "group mx-2 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-white/80 transition-colors hover:bg-white/10 hover:text-white",
-                                        item.active && "bg-white/10 text-white"
-                                    )}
-                                >
-                                    <item.icon className={cn("h-4 w-4 text-white/50 group-hover:text-white", item.active && "text-white")} />
-                                    <span className="flex-1">{item.label}</span>
-                                    {item.active && <ArrowRight className="h-3 w-3 text-white/50" />}
-                                </div>
-                            ))}
+            <Dialog open={open} onOpenChange={setOpen}>
+                <DialogContent className="overflow-hidden p-0 shadow-2xl w-[95vw] max-w-[550px] bg-[#0a0a0a] border-white/10 rounded-xl">
+                    <div className="flex items-center border-b border-white/10 px-4" cmdk-input-wrapper="">
+                        <Search className="mr-2 h-4 w-4 shrink-0 opacity-50 text-white" />
+                        <input
+                            className="flex h-12 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-white/50 text-white disabled:cursor-not-allowed disabled:opacity-50"
+                            placeholder={language === "en" ? "Type a command or search..." : "Escribe un comando o busca..."}
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            autoFocus
+                        />
+                        <div className="hidden sm:flex items-center gap-1 text-xs text-white/40">
+                            <kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border border-white/10 bg-white/5 px-1.5 font-mono font-medium opacity-100">
+                                <span className="text-xs">ESC</span>
+                            </kbd>
                         </div>
-                    ))}
-                </div>
-                <div className="border-t border-white/10 px-4 py-2.5 text-xs text-white/40 flex justify-between">
-                    <span>
-                        {language === "en" ? "Pro tip: Use" : "Tip: Usa"} <kbd className="font-sans">↑</kbd> <kbd className="font-sans">↓</kbd> {language === "en" ? "to navigate" : "para navegar"}
-                    </span>
-                    <span>
-                        Portfolio v2.0
-                    </span>
-                </div>
-            </DialogContent>
-        </Dialog>
+                    </div>
+                    <div className="max-h-[300px] overflow-y-auto overflow-x-hidden py-2">
+                        {filteredGroups.length === 0 && (
+                            <div className="py-6 text-center text-sm text-white/50">
+                                {language === "en" ? "No results found." : "No se encontraron resultados."}
+                            </div>
+                        )}
+
+                        {filteredGroups.map((group, i) => (
+                            <div key={group.heading} className="mb-2">
+                                <div className="px-4 py-1.5 text-xs font-medium text-white/40 uppercase tracking-wider">
+                                    {group.heading}
+                                </div>
+                                {group.items.map((item, j) => (
+                                    <div
+                                        key={item.label}
+                                        onClick={() => runCommand(item.action)}
+                                        className={cn(
+                                            "group mx-2 flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-white/80 transition-colors hover:bg-white/10 hover:text-white",
+                                            item.active && "bg-white/10 text-white"
+                                        )}
+                                    >
+                                        <item.icon className={cn("h-4 w-4 text-white/50 group-hover:text-white", item.active && "text-white")} />
+                                        <span className="flex-1">{item.label}</span>
+                                        {item.active && <ArrowRight className="h-3 w-3 text-white/50" />}
+                                    </div>
+                                ))}
+                            </div>
+                        ))}
+                    </div>
+                    <div className="hidden sm:flex border-t border-white/10 px-4 py-2.5 text-xs text-white/40 justify-between">
+                        <span>
+                            {language === "en" ? "Pro tip: Use" : "Tip: Usa"} <kbd className="font-sans">↑</kbd> <kbd className="font-sans">↓</kbd> {language === "en" ? "to navigate" : "para navegar"}
+                        </span>
+                        <span>
+                            Portfolio v2.0
+                        </span>
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </>
     );
 }

--- a/src/components/portfolio/features/tech-stack-architecture.tsx
+++ b/src/components/portfolio/features/tech-stack-architecture.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Database, Server, Layers, BarChart3, GitBranch, Terminal, Cloud, Shield, Cpu, Globe } from "lucide-react";
+import { Database, Server, Layers, BarChart3, GitBranch, Terminal, Cloud, Shield, Cpu, Globe, Activity } from "lucide-react";
 import { PortfolioToolboxGroup } from "@/data/profiles/types";
 import { cn } from "@/lib/utils";
 
@@ -39,7 +39,15 @@ export function TechStackArchitecture({ profile, toolbox }: TechStackArchitectur
     return null;
 }
 
-function StackCard({ title, items, icon: Icon, color, className }: any) {
+interface StackCardProps {
+    title: string;
+    items: string[];
+    icon: React.ElementType;
+    color: string;
+    className?: string;
+}
+
+function StackCard({ title, items, icon: Icon, color, className }: StackCardProps) {
     return (
         <motion.div
             className={cn(
@@ -144,5 +152,3 @@ function DataAnalystStack({ toolbox }: { toolbox: PortfolioToolboxGroup[] }) {
         </div>
     );
 }
-
-import { Activity } from "lucide-react";

--- a/src/components/portfolio/features/thematic-process.tsx
+++ b/src/components/portfolio/features/thematic-process.tsx
@@ -4,9 +4,27 @@ import { motion } from "framer-motion";
 import { PortfolioProcessStep, resolveText } from "@/data/profiles/types";
 import { useI18n } from "@/contexts/i18n-context";
 import { useProfile } from "@/contexts/profile-context";
-import { resolveIcon } from "../icon-map";
+// import { resolveIcon } from "@/components/portfolio/icon-map";
 import { cn } from "@/lib/utils";
-import { ArrowRight, RefreshCw, GitMerge, Search } from "lucide-react";
+import { ArrowRight, RefreshCw, GitMerge, Search, Workflow, Gauge, Activity, ShieldCheck, CircuitBoard, BarChart4, LineChart, AlarmCheck, Brain, CloudCog, DatabaseZap, Network } from "lucide-react";
+
+function resolveIcon(token: string, className = "h-5 w-5") {
+    const iconMap: Record<string, JSX.Element> = {
+        pipeline: <Workflow className={className} />,
+        delivery: <Gauge className={className} />,
+        monitoring: <Activity className={className} />,
+        quality: <ShieldCheck className={className} />,
+        automation: <CircuitBoard className={className} />,
+        dashboard: <BarChart4 className={className} />,
+        insights: <LineChart className={className} />,
+        recovery: <AlarmCheck className={className} />,
+        ai: <Brain className={className} />,
+        cloud: <CloudCog className={className} />,
+        data: <DatabaseZap className={className} />,
+    };
+
+    return iconMap[token] ?? <Network className={className} />;
+}
 
 interface ThematicProcessProps {
     steps: PortfolioProcessStep[];

--- a/src/components/portfolio/features/thematic-process.tsx
+++ b/src/components/portfolio/features/thematic-process.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { PortfolioProcessStep, resolveText } from "@/data/profiles/types";
+import { useI18n } from "@/contexts/i18n-context";
+import { useProfile } from "@/contexts/profile-context";
+import { resolveIcon } from "../icon-map";
+import { cn } from "@/lib/utils";
+import { ArrowRight, RefreshCw, GitMerge, Search } from "lucide-react";
+
+interface ThematicProcessProps {
+    steps: PortfolioProcessStep[];
+}
+
+export function ThematicProcess({ steps }: ThematicProcessProps) {
+    const { profile } = useProfile();
+    const { language } = useI18n();
+
+    const commonProps = { steps, language };
+
+    switch (profile) {
+        case "data-engineer":
+            return <DataEngineerDAG {...commonProps} />;
+        case "devops-engineer":
+            return <DevOpsInfinityLoop {...commonProps} />;
+        case "ml-engineer":
+            return <MLFeedbackLoop {...commonProps} />;
+        case "data-analyst":
+            return <AnalystFunnel {...commonProps} />;
+        default:
+            return <DefaultProcess {...commonProps} />;
+    }
+}
+
+// --- 1. Data Engineer: DAG Visualization ---
+function DataEngineerDAG({ steps, language }: any) {
+    return (
+        <div className="relative flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
+            {/* Connecting Line (Desktop) */}
+            <div className="absolute left-0 top-8 hidden h-0.5 w-full bg-white/10 md:block">
+                <motion.div
+                    className="h-full bg-gradient-to-r from-blue-500 via-purple-500 to-emerald-500"
+                    initial={{ width: "0%" }}
+                    whileInView={{ width: "100%" }}
+                    transition={{ duration: 1.5, ease: "easeInOut" }}
+                />
+            </div>
+
+            {steps.map((step: PortfolioProcessStep, index: number) => (
+                <motion.div
+                    key={index}
+                    className="relative z-10 flex flex-1 flex-col gap-4 md:items-center md:text-center"
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.2 }}
+                >
+                    {/* Node */}
+                    <div className="flex h-16 w-16 items-center justify-center rounded-2xl border border-white/10 bg-black shadow-xl transition-transform hover:scale-110">
+                        <div className={cn(
+                            "flex h-10 w-10 items-center justify-center rounded-lg",
+                            index === 0 ? "bg-blue-500/20 text-blue-400" :
+                                index === 1 ? "bg-purple-500/20 text-purple-400" :
+                                    "bg-emerald-500/20 text-emerald-400"
+                        )}>
+                            {resolveIcon(step.icon, "h-5 w-5")}
+                        </div>
+                    </div>
+
+                    {/* Content */}
+                    <div className="rounded-xl border border-white/5 bg-white/5 p-4 backdrop-blur-sm md:w-full md:max-w-[280px]">
+                        <h3 className="mb-2 font-semibold text-white">{resolveText(step.title, language)}</h3>
+                        <p className="text-sm text-white/60">{resolveText(step.description, language)}</p>
+                    </div>
+                </motion.div>
+            ))}
+        </div>
+    );
+}
+
+// --- 2. DevOps Engineer: Infinity Loop (Simplified) ---
+function DevOpsInfinityLoop({ steps, language }: any) {
+    return (
+        <div className="relative grid gap-8 md:grid-cols-3">
+            {/* Loop SVG Background */}
+            <svg className="absolute inset-0 -z-10 h-full w-full opacity-20" viewBox="0 0 800 200" preserveAspectRatio="none">
+                <path
+                    d="M 100 100 C 100 100, 200 0, 400 100 C 600 200, 700 100, 700 100"
+                    fill="none"
+                    stroke="url(#gradient)"
+                    strokeWidth="4"
+                    strokeDasharray="10 10"
+                />
+                <defs>
+                    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+                        <stop offset="0%" stopColor="#3b82f6" />
+                        <stop offset="100%" stopColor="#10b981" />
+                    </linearGradient>
+                </defs>
+            </svg>
+
+            {steps.map((step: PortfolioProcessStep, index: number) => (
+                <motion.div
+                    key={index}
+                    className="group relative overflow-hidden rounded-2xl border border-white/10 bg-black/40 p-6 backdrop-blur-md transition-all hover:border-white/20"
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    whileInView={{ opacity: 1, scale: 1 }}
+                    transition={{ delay: index * 0.2 }}
+                >
+                    <div className="mb-4 flex items-center justify-between">
+                        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white/5 text-white/80">
+                            {resolveIcon(step.icon, "h-5 w-5")}
+                        </div>
+                        <span className="font-mono text-xs text-white/30">0{index + 1}</span>
+                    </div>
+                    <h3 className="mb-2 text-lg font-semibold text-white">{resolveText(step.title, language)}</h3>
+                    <p className="text-sm text-white/60">{resolveText(step.description, language)}</p>
+
+                    {/* Animated Border on Hover */}
+                    <div className="absolute bottom-0 left-0 h-1 w-full bg-gradient-to-r from-blue-500 to-emerald-500 opacity-0 transition-opacity group-hover:opacity-100" />
+                </motion.div>
+            ))}
+        </div>
+    );
+}
+
+// --- 3. ML Engineer: Feedback Loop ---
+function MLFeedbackLoop({ steps, language }: any) {
+    return (
+        <div className="grid gap-6 md:grid-cols-3">
+            {steps.map((step: PortfolioProcessStep, index: number) => (
+                <motion.div
+                    key={index}
+                    className="relative flex flex-col rounded-2xl border border-purple-500/20 bg-purple-950/10 p-6 backdrop-blur-sm"
+                    initial={{ opacity: 0, x: -20 }}
+                    whileInView={{ opacity: 1, x: 0 }}
+                    transition={{ delay: index * 0.2 }}
+                >
+                    {/* Connector Arrow */}
+                    {index < steps.length - 1 && (
+                        <div className="absolute -right-3 top-1/2 z-10 hidden -translate-y-1/2 translate-x-1/2 rounded-full bg-purple-500/20 p-1 md:block">
+                            <ArrowRight className="h-4 w-4 text-purple-400" />
+                        </div>
+                    )}
+
+                    {/* Last item loops back visual hint */}
+                    {index === steps.length - 1 && (
+                        <div className="absolute -bottom-3 left-1/2 z-10 hidden -translate-x-1/2 translate-y-1/2 rounded-full bg-purple-500/20 p-1 md:block">
+                            <RefreshCw className="h-4 w-4 text-purple-400" />
+                        </div>
+                    )}
+
+                    <div className="mb-4 inline-flex w-fit rounded-lg bg-purple-500/20 p-2 text-purple-300">
+                        {resolveIcon(step.icon, "h-5 w-5")}
+                    </div>
+
+                    <h3 className="mb-2 text-lg font-semibold text-white">{resolveText(step.title, language)}</h3>
+                    <p className="text-sm text-white/60">{resolveText(step.description, language)}</p>
+
+                    <div className="mt-4 border-t border-white/5 pt-4">
+                        <p className="text-xs font-medium text-purple-300/70">{resolveText(step.detail, language)}</p>
+                    </div>
+                </motion.div>
+            ))}
+        </div>
+    );
+}
+
+// --- 4. Data Analyst: Funnel / Insight Generation ---
+function AnalystFunnel({ steps, language }: any) {
+    return (
+        <div className="flex flex-col gap-4">
+            {steps.map((step: PortfolioProcessStep, index: number) => (
+                <motion.div
+                    key={index}
+                    className="relative flex items-center gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm transition-colors hover:bg-white/10"
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.15 }}
+                    // Funnel width effect
+                    style={{
+                        marginLeft: `${index * 2}rem`,
+                        marginRight: `${index * 2}rem`
+                    }}
+                >
+                    <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-blue-500/20 text-blue-400">
+                        {resolveIcon(step.icon, "h-6 w-6")}
+                    </div>
+
+                    <div className="flex-1">
+                        <h3 className="text-lg font-semibold text-white">{resolveText(step.title, language)}</h3>
+                        <p className="text-sm text-white/60">{resolveText(step.description, language)}</p>
+                    </div>
+
+                    <div className="hidden text-right text-xs text-white/40 md:block">
+                        Step 0{index + 1}
+                    </div>
+                </motion.div>
+            ))}
+
+            {/* Result Box */}
+            <motion.div
+                className="mx-auto mt-4 flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-6 py-2 text-emerald-400"
+                initial={{ opacity: 0, scale: 0.8 }}
+                whileInView={{ opacity: 1, scale: 1 }}
+                transition={{ delay: 0.6 }}
+            >
+                <Search className="h-4 w-4" />
+                <span className="text-sm font-medium">Actionable Insight</span>
+            </motion.div>
+        </div>
+    );
+}
+
+// --- Default Fallback ---
+function DefaultProcess({ steps, language }: any) {
+    return (
+        <ol className="relative grid gap-6 md:grid-cols-3">
+            {steps.map((step: PortfolioProcessStep, index: number) => (
+                <motion.li
+                    key={resolveText(step.title, language)}
+                    className="group relative rounded-3xl border border-white/10 bg-white/[0.05] p-6 backdrop-blur transition-all duration-300 hover:-translate-y-2 hover:bg-white/[0.08]"
+                    initial={{ opacity: 0, y: 24 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.1 }}
+                >
+                    <div className="absolute inset-x-0 -top-[1px] h-[3px] rounded-full bg-gradient-to-r from-[hsla(var(--portfolio-primary),0.6)] to-[hsla(var(--portfolio-accent),0.5)] opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+                    <div className="flex items-center justify-between">
+                        <span className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/10 text-white">
+                            {index + 1}
+                        </span>
+                        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[hsla(var(--portfolio-primary),0.12)] text-white/80">
+                            {resolveIcon(step.icon, "h-5 w-5")}
+                        </span>
+                    </div>
+                    <div className="mt-6 space-y-3">
+                        <h3 className="text-xl font-semibold text-white">
+                            {resolveText(step.title, language)}
+                        </h3>
+                        <p className="text-sm text-white/70">{resolveText(step.description, language)}</p>
+                        <p className="text-sm text-white/55">{resolveText(step.detail, language)}</p>
+                    </div>
+                </motion.li>
+            ))}
+        </ol>
+    );
+}

--- a/src/components/portfolio/human-section.tsx
+++ b/src/components/portfolio/human-section.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import { PortfolioAnecdote, PortfolioWorkingStyle, resolveText } from "@/data/profiles/types";
 import { useI18n } from "@/contexts/i18n-context";
+import { ActivityGraph } from "./activity-graph";
 
 interface HumanSectionProps {
   anecdote: PortfolioAnecdote;
@@ -121,6 +122,16 @@ export function HumanSection({ anecdote, workingStyle, onSectionView }: HumanSec
           </div>
         </div>
       </motion.aside>
+
+      <motion.div
+        className="lg:col-span-2"
+        initial={{ opacity: 0, y: 20 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true, margin: "-60px" }}
+        transition={{ duration: 0.4, delay: 0.2 }}
+      >
+        <ActivityGraph />
+      </motion.div>
     </section>
   );
 }

--- a/src/components/portfolio/portfolio-layout.tsx
+++ b/src/components/portfolio/portfolio-layout.tsx
@@ -12,6 +12,7 @@ import { GuaranteesSection } from "./guarantees-section";
 import { TestimonialsSection } from "./testimonials-section";
 import { HumanSection } from "./human-section";
 import { FinalCta } from "./final-cta";
+import { CommandMenu } from "./command-menu";
 
 export interface PortfolioLayoutProps {
   metadata: ProfileMetadata;
@@ -34,6 +35,7 @@ export function PortfolioLayout({
 }: PortfolioLayoutProps) {
   return (
     <div className={`portfolio-theme ${metadata.themeClass}`}>
+      <CommandMenu />
       <div className="portfolio-surface relative flex min-h-screen w-full flex-col gap-10 sm:gap-12 md:gap-14 bg-[hsl(var(--portfolio-bg))] px-4 sm:px-6 md:px-8 lg:px-12 xl:px-16 py-8 sm:py-10">
         <div className="absolute inset-0 -z-10 bg-[hsla(var(--portfolio-shadow),0.85)]" />
         <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 sm:gap-12 md:gap-14">

--- a/src/components/portfolio/process-timeline.tsx
+++ b/src/components/portfolio/process-timeline.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import { PortfolioProcessStep, resolveText } from "@/data/profiles/types";
-import { resolveIcon } from "./icon-map";
 import { useI18n } from "@/contexts/i18n-context";
+import { ThematicProcess } from "./features/thematic-process";
 
 interface ProcessTimelineProps {
   steps: PortfolioProcessStep[];
@@ -56,8 +56,7 @@ export function ProcessTimeline({ steps, onSectionView }: ProcessTimelineProps) 
         </p>
       </motion.div>
 
-      <motion.ol
-        className="relative grid gap-6 md:grid-cols-3"
+      <motion.div
         initial="hidden"
         whileInView="visible"
         viewport={{ once: true, margin: "-60px" }}
@@ -70,34 +69,8 @@ export function ProcessTimeline({ steps, onSectionView }: ProcessTimelineProps) 
           },
         }}
       >
-        {steps.map((step, index) => (
-          <motion.li
-            key={resolveText(step.title, language)}
-            className="group relative rounded-3xl border border-white/10 bg-white/[0.05] p-6 backdrop-blur transition-all duration-300 hover:-translate-y-2 hover:bg-white/[0.08]"
-            variants={{
-              hidden: { opacity: 0, y: 24 },
-              visible: { opacity: 1, y: 0 },
-            }}
-          >
-            <div className="absolute inset-x-0 -top-[1px] h-[3px] rounded-full bg-gradient-to-r from-[hsla(var(--portfolio-primary),0.6)] to-[hsla(var(--portfolio-accent),0.5)] opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-            <div className="flex items-center justify-between">
-              <span className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/10 text-white">
-                {index + 1}
-              </span>
-              <span className="flex h-10 w-10 items-center justify-center rounded-full bg-[hsla(var(--portfolio-primary),0.12)] text-white/80">
-                {resolveIcon(step.icon, "h-5 w-5")}
-              </span>
-            </div>
-            <div className="mt-6 space-y-3">
-              <h3 className="text-xl font-semibold text-white">
-                {resolveText(step.title, language)}
-              </h3>
-              <p className="text-sm text-white/70">{resolveText(step.description, language)}</p>
-              <p className="text-sm text-white/55">{resolveText(step.detail, language)}</p>
-            </div>
-          </motion.li>
-        ))}
-      </motion.ol>
+        <ThematicProcess steps={steps} />
+      </motion.div>
     </section>
   );
 }

--- a/src/components/portfolio/tool-icon-utils.tsx
+++ b/src/components/portfolio/tool-icon-utils.tsx
@@ -93,6 +93,25 @@ export function createToolIconNode(
   );
 }
 
+export function slugifyToolName(name: string): string {
+  const map: Record<string, string> = {
+    "TensorFlow Serving": "tensorflow",
+    "Argo Workflows": "argo",
+    "Github Actions": "githubactions",
+    "Airflow": "apacheairflow",
+    "Next.js": "nextdotjs",
+    "Node.js": "nodedotjs",
+    "C++": "cplusplus",
+    "C#": "csharp",
+    ".NET": "dotnet",
+    "scikit-learn": "scikitlearn",
+  };
+
+  if (map[name]) return map[name];
+
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
 
 
 

--- a/src/components/portfolio/toolbox-section.tsx
+++ b/src/components/portfolio/toolbox-section.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useMemo } from "react";
 import { motion } from "framer-motion";
 import { PortfolioToolboxGroup, resolveText } from "@/data/profiles/types";
-import { IconCloud } from "@/components/ui/icon-cloud";
-import { createToolIconNode } from "./tool-icon-utils";
+import IconCloud from "@/components/magicui/icon-cloud";
+import { createToolIconNode, slugifyToolName } from "./tool-icon-utils";
 import { TechSphere } from "./tech-sphere";
 import { useI18n } from "@/contexts/i18n-context";
 import { TechStackArchitecture } from "./features/tech-stack-architecture";
@@ -84,14 +84,10 @@ export function ToolboxSection({ toolbox, coreTools = [], onSectionView }: Toolb
   // Flatten all tools for display
   const allTools = toolbox.flatMap(group => group.items);
   const hasCore = coreTools.length > 0;
-  const toolboxIcons = useMemo(
+  const iconSlugs = useMemo(
     () =>
-      toolbox.flatMap((group, groupIndex) =>
-        group.items.map((item, itemIndex) =>
-          createToolIconNode(item, {
-            accentIndex: groupIndex * 4 + itemIndex,
-          }),
-        ),
+      toolbox.flatMap((group) =>
+        group.items.map((item) => slugifyToolName(item))
       ),
     [toolbox],
   );
@@ -234,7 +230,7 @@ export function ToolboxSection({ toolbox, coreTools = [], onSectionView }: Toolb
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.22),transparent_60%)]" />
             <div className="relative flex flex-col items-center gap-6">
               <div className="relative flex h-[320px] w-full max-w-[320px] items-center justify-center sm:h-[400px] sm:max-w-[400px]">
-                <IconCloud icons={toolboxIcons} />
+                <IconCloud iconSlugs={iconSlugs} />
               </div>
               <div className="text-center">
                 <p className="text-sm font-semibold uppercase tracking-[0.4em] text-white/50">

--- a/src/components/portfolio/toolbox-section.tsx
+++ b/src/components/portfolio/toolbox-section.tsx
@@ -233,7 +233,7 @@ export function ToolboxSection({ toolbox, coreTools = [], onSectionView }: Toolb
           >
             <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.22),transparent_60%)]" />
             <div className="relative flex flex-col items-center gap-6">
-              <div className="relative flex items-center justify-center">
+              <div className="relative flex h-[320px] w-full max-w-[320px] items-center justify-center sm:h-[400px] sm:max-w-[400px]">
                 <IconCloud icons={toolboxIcons} />
               </div>
               <div className="text-center">

--- a/src/components/ui/icon-cloud.tsx
+++ b/src/components/ui/icon-cloud.tsx
@@ -77,14 +77,20 @@ export function IconCloud({ icons, images }: IconCloudProps) {
           }
         } else {
           // Handle SVG icons
-          offCtx.scale(0.4, 0.4)
           const svgString = renderToString(item as React.ReactElement)
           const img = new Image()
-          img.src = "data:image/svg+xml;base64," + btoa(svgString)
+          // Fix for Unicode characters in SVG string (e.g. accents in tool names)
+          const encodedSvg = btoa(unescape(encodeURIComponent(svgString)))
+          img.src = "data:image/svg+xml;base64," + encodedSvg
+          
           img.onload = () => {
             offCtx.clearRect(0, 0, offscreen.width, offscreen.height)
-            offCtx.drawImage(img, 0, 0)
+            // Draw image scaled to fit the canvas (40x40)
+            offCtx.drawImage(img, 0, 0, 40, 40)
             imagesLoadedRef.current[index] = true
+          }
+          img.onerror = (e) => {
+            console.error("Error loading icon:", e)
           }
         }
       }

--- a/src/components/ui/icon-cloud.tsx
+++ b/src/components/ui/icon-cloud.tsx
@@ -82,7 +82,7 @@ export function IconCloud({ icons, images }: IconCloudProps) {
           // Fix for Unicode characters in SVG string (e.g. accents in tool names)
           const encodedSvg = btoa(unescape(encodeURIComponent(svgString)))
           img.src = "data:image/svg+xml;base64," + encodedSvg
-          
+
           img.onload = () => {
             offCtx.clearRect(0, 0, offscreen.width, offscreen.height)
             // Draw image scaled to fit the canvas (40x40)

--- a/src/components/ui/icon-cloud.tsx
+++ b/src/components/ui/icon-cloud.tsx
@@ -319,7 +319,7 @@ export function IconCloud({ icons, images }: IconCloudProps) {
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
-      className="rounded-lg"
+      className="h-full w-full object-contain"
       aria-label="Interactive 3D Icon Cloud"
       role="img"
     />

--- a/src/data/profiles/ml-engineer.tsx
+++ b/src/data/profiles/ml-engineer.tsx
@@ -149,6 +149,29 @@ export const mlEngineerProfile: ProfileData = {
         alt: "Panel de monitoreo Qalma",
       },
       highlight: true,
+      codeSnippet: {
+        language: "python",
+        file: "pipeline.py",
+        code: `
+@flow(name="eeg-training-pipeline")
+def train_model(batch_id: str):
+    # 1. Load validated data from Feature Store
+    X, y = load_features(batch_id, version="prod")
+    
+    # 2. Train with experiment tracking
+    with mlflow.start_run():
+        model = TensorFlowClassifier()
+        model.fit(X, y)
+        
+        # 3. Log metrics & artifacts
+        mlflow.log_metrics({"accuracy": model.score(X, y)})
+        mlflow.tensorflow.log_model(model, "model")
+        
+    # 4. Register if beats baseline
+    if model.accuracy > 0.85:
+        register_model(model, stage="Staging")
+`
+      }
     },
     {
       title: l("Observable microservices", "Microservicios observables"),

--- a/src/data/profiles/types.ts
+++ b/src/data/profiles/types.ts
@@ -86,6 +86,11 @@ export interface PortfolioCaseStudy {
   media: PortfolioCaseMedia;
   highlight?: boolean;
   quickRead?: boolean;
+  codeSnippet?: {
+    language: string;
+    code: string;
+    file: string;
+  };
 }
 
 export interface PortfolioToolboxGroup {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a floating command menu, coding activity graph, profile-specific thematic process, code-snippet viewer in case studies, revamped icon cloud inputs, and moves theme color to Next.js viewport.
> 
> - **UI/UX**:
>   - **Command Menu**: Add floating command palette (`src/components/portfolio/command-menu.tsx`) and render it in `PortfolioLayout`.
>   - **Human Section**: Add `ActivityGraph` heatmap and integrate into `human-section`.
>   - **Process**: Replace static timeline with profile-specific `ThematicProcess` (DAG/loop/funnel variants) and wire into `process-timeline`.
> - **Case Studies**:
>   - Add in-card code snippet viewer with overlay toggle in `case-showcase`; extend `PortfolioCaseStudy` with `codeSnippet` and add snippet to ML Engineer profile.
> - **Tooling Visuals**:
>   - Switch icon cloud to `magicui/icon-cloud` using slug-based `iconSlugs`; add `slugifyToolName`; adjust canvas sizing and SVG encoding in `ui/icon-cloud`.
>   - Minor refactor: type-safe `StackCard` props and add `Activity` icon in tech stack architecture.
> - **PWA/SEO**:
>   - Move `themeColor` to exported `viewport`; remove manual `<head>` meta/apple tags in `layout`.
>   - Manifest cleanup (reformat categories; remove screenshots).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 015cb0e5c5e1c61a457f2decc80b5fa03c8e92f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->