### PR TITLE
feat(seo): add image sitemap and crawler rules

### DIFF
--- a/src/app/robots.test.ts
+++ b/src/app/robots.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import robots from './robots';
+
+const AI_CRAWLERS = [
+  'GPTBot',
+  'OAI-SearchBot',
+  'ChatGPT-User',
+  'PerplexityBot',
+  'FirecrawlAgent',
+  'Diffbot',
+  'Bytespider',
+  'CCBot',
+  'GoogleOther',
+  'Bingbot',
+] as const;
+
+type NormalizedRule = {
+  userAgent: string;
+  allow?: string | string[];
+  disallow?: string[];
+};
+
+function allRules(): NormalizedRule[] {
+  const { rules } = robots();
+  return (Array.isArray(rules) ? rules : [rules]).map((rule) => ({
+    userAgent: Array.isArray(rule.userAgent) ? rule.userAgent.join(',') : rule.userAgent ?? '',
+    allow: rule.allow,
+    disallow: Array.isArray(rule.disallow) ? rule.disallow : rule.disallow ? [rule.disallow] : undefined,
+  }));
+}
+
+describe('robots()', () => {
+  it('keeps /api/ and /_next/ blocked for the wildcard user agent', () => {
+    const wildcard = allRules().find((rule) => rule.userAgent === '*')!;
+    expect(wildcard).toBeDefined();
+    expect(wildcard.allow).toBe('/');
+    expect(wildcard.disallow).toEqual(expect.arrayContaining(['/api/', '/_next/']));
+  });
+
+  it('explicitly allows / for every AI crawler', () => {
+    const rules = allRules();
+    for (const crawler of AI_CRAWLERS) {
+      const rule = rules.find((r) => r.userAgent === crawler)!;
+      expect(rule, `${crawler} should have an allow rule`).toBeDefined();
+      expect(rule.allow).toBe('/');
+      expect(rule.disallow).toBeUndefined();
+    }
+  });
+
+  it('never blocks the whole site for any user agent', () => {
+    for (const rule of allRules()) {
+      expect(rule.disallow ?? []).not.toContain('/');
+    }
+  });
+});

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -3,12 +3,28 @@ import type { MetadataRoute } from 'next';
 const BASE_URL = 'https://www.dvillagrans.dev';
 
 export default function robots(): MetadataRoute.Robots {
+  const aiCrawlers = [
+    'GPTBot',
+    'OAI-SearchBot',
+    'ChatGPT-User',
+    'PerplexityBot',
+    'FirecrawlAgent',
+    'Diffbot',
+    'Bytespider',
+    'CCBot',
+    'GoogleOther',
+    'Bingbot',
+  ] as const;
+
   return {
-    rules: {
-      userAgent: '*',
-      allow: '/',
-      disallow: ['/api/', '/_next/'],
-    },
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/_next/'],
+      },
+      ...aiCrawlers.map((userAgent) => ({ userAgent, allow: '/' })),
+    ],
     sitemap: `${BASE_URL}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.test.ts
+++ b/src/app/sitemap.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import sitemap from './sitemap';
+
+const PUBLIC_DIR = join(process.cwd(), 'public');
+
+describe('sitemap()', () => {
+  it('returns absolute URLs for every entry', () => {
+    const entries = sitemap();
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) {
+      expect(entry.url).toMatch(/^https:\/\/www\./);
+    }
+  });
+
+  it('references only images that exist under public/', () => {
+    for (const entry of sitemap()) {
+      for (const image of entry.images ?? []) {
+        const { pathname } = new URL(image);
+        expect(
+          existsSync(join(PUBLIC_DIR, pathname)),
+          `${pathname} should exist under public/`
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('does not include /cv-builder', () => {
+    const urls = sitemap().map((entry) => entry.url);
+    expect(urls.some((url) => url.includes('/cv-builder'))).toBe(false);
+  });
+});

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,18 +6,20 @@ const BASE_URL = 'https://www.dvillagrans.dev';
 const LAST_MODIFIED = '2026-06-18';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const staticRoutes = [
+  const staticRoutes: MetadataRoute.Sitemap = [
     {
       url: BASE_URL,
       lastModified: LAST_MODIFIED,
       changeFrequency: 'monthly' as const,
       priority: 1,
+      images: [`${BASE_URL}/img/portfolio.webp`],
     },
     {
       url: `${BASE_URL}/about`,
       lastModified: LAST_MODIFIED,
       changeFrequency: 'monthly' as const,
       priority: 0.9,
+      images: [`${BASE_URL}/img/optimized/me-1200.webp`],
     },
     {
       url: `${BASE_URL}/projects`,
@@ -30,24 +32,28 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: LAST_MODIFIED,
       changeFrequency: 'monthly' as const,
       priority: 0.8,
+      images: [`${BASE_URL}/img/eyenet.webp`],
     },
     {
       url: `${BASE_URL}/projects/covid`,
       lastModified: LAST_MODIFIED,
       changeFrequency: 'monthly' as const,
       priority: 0.8,
+      images: [`${BASE_URL}/img/dashboard-covid-19.webp`],
     },
     {
       url: `${BASE_URL}/projects/nyc`,
       lastModified: LAST_MODIFIED,
       changeFrequency: 'monthly' as const,
       priority: 0.8,
+      images: [`${BASE_URL}/img/nyc-ridehailing-dashboard.webp`],
     },
     {
       url: `${BASE_URL}/projects/india`,
       lastModified: LAST_MODIFIED,
       changeFrequency: 'monthly' as const,
       priority: 0.8,
+      images: [`${BASE_URL}/img/india-air-quality.webp`],
     },
     {
       url: `${BASE_URL}/projects/bouquet`,
@@ -60,6 +66,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: LAST_MODIFIED,
       changeFrequency: 'monthly' as const,
       priority: 0.8,
+      images: [`${BASE_URL}/img/timeup-mock.webp`],
     },
     {
       url: `${BASE_URL}/now`,


### PR DESCRIPTION
Closes #33

## Summary
- Añade imágenes públicas relevantes a las entradas del sitemap.
- Expone reglas explícitas de allow para los crawlers solicitados.
- Conserva el bloqueo de `/api/` y `/_next/` para el wildcard y añade pruebas de regresión.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 124 tests
- [x] `pnpm build`
- [x] `pnpm audit --prod`
- [x] `git diff --check`

## Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers
- [ ] Automated checks pending