### PR TITLE
perf(seo): reduce mobile main-thread work

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,11 +3,11 @@ import { ConsoleEasterEgg } from '@/components/ui/ConsoleEasterEgg';
 import { ViewTransitionDirector } from '@/components/ui/ViewTransitionDirector';
 import GridOverlay from '@/components/ui/GridOverlay';
 import { PersonSchema, WebSiteSchema } from '@/components/ui/SchemaOrg';
-import { CommandPalette } from '@/components/ui/CommandPalette';
+import { CommandPaletteLazy } from '@/components/ui/CommandPaletteLazy';
 import { CommandPaletteProvider } from '@/hooks/CommandPaletteContext';
 import { CustomCursor } from '@/components/ui/CustomCursor';
 import type { Metadata } from "next";
-import { Inter, Space_Grotesk, EB_Garamond, JetBrains_Mono } from "next/font/google";
+import { Inter, EB_Garamond, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { LanguageProvider } from "@/i18n/LanguageContext";
 import { ThemeProvider } from "@/hooks/ThemeContext";
@@ -17,12 +17,6 @@ import { Analytics } from "@vercel/analytics/react";
 
 const inter = Inter({
   variable: "--font-inter",
-  subsets: ["latin"],
-  weight: ["300", "400", "500", "600", "700"],
-});
-
-const spaceGrotesk = Space_Grotesk({
-  variable: "--font-space-grotesk",
   subsets: ["latin"],
   weight: ["300", "400", "500", "600", "700"],
 });
@@ -157,7 +151,7 @@ export default function RootLayout({
         )}
       </head>
       <body
-        className={`${inter.variable} ${spaceGrotesk.variable} ${ebGaramond.variable} ${jetbrainsMono.variable} font-sans overflow-x-hidden selection:bg-accent selection:text-offwhite`}
+        className={`${inter.variable} ${ebGaramond.variable} ${jetbrainsMono.variable} font-sans overflow-x-hidden selection:bg-accent selection:text-offwhite`}
       >
         <a
           href="#main-content"
@@ -178,7 +172,7 @@ export default function RootLayout({
               <div className="noise-overlay pointer-events-none fixed inset-0 z-50 h-full w-full opacity-[0.03] mix-blend-overlay" aria-hidden="true"></div>
               {children}
               <ProjectChat />
-              <CommandPalette />
+              <CommandPaletteLazy />
               <CustomCursor />
             </CommandPaletteProvider>
           </LanguageProvider>

--- a/src/components/case-study/CaseStudyHeroMedia.test.tsx
+++ b/src/components/case-study/CaseStudyHeroMedia.test.tsx
@@ -1,10 +1,31 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CaseStudyHeroMedia } from "@/components/case-study/CaseStudyHeroMedia";
 import { getCaseStudyMedia } from "@/data/case-study-media";
 
+function makeIntersectionObserver(intersecting: boolean) {
+  return class MockIntersectionObserver implements IntersectionObserver {
+    readonly root: Element | Document | null = null;
+    readonly rootMargin = "";
+    readonly thresholds: readonly number[] = [];
+    constructor(private readonly callback: IntersectionObserverCallback) {}
+
+    observe = (target: Element) => {
+      this.callback([{ isIntersecting: intersecting, target } as IntersectionObserverEntry], this);
+    };
+    disconnect = vi.fn();
+    unobserve = vi.fn();
+    takeRecords = () => [];
+  };
+}
+
 describe("CaseStudyHeroMedia", () => {
   afterEach(() => cleanup());
+
+  beforeEach(() => {
+    // Default back to the jsdom stub (not intersecting).
+    vi.stubGlobal("IntersectionObserver", makeIntersectionObserver(false));
+  });
 
   it("renders poster image when no video is configured", () => {
     render(<CaseStudyHeroMedia media={getCaseStudyMedia("nyc")} />);
@@ -19,6 +40,7 @@ describe("CaseStudyHeroMedia", () => {
   });
 
   it("plays video in featured mode only when the scene is active", () => {
+    vi.stubGlobal("IntersectionObserver", makeIntersectionObserver(true));
     const { rerender } = render(
       <CaseStudyHeroMedia
         media={getCaseStudyMedia("covid")}
@@ -42,5 +64,21 @@ describe("CaseStudyHeroMedia", () => {
     );
     expect(document.querySelector("video")).toBeTruthy();
     expect(document.querySelector("video")?.getAttribute("aria-label")).toMatch(/covid-19 risk profiles/i);
+  });
+
+  it("holds active-scene video until the frame is near the viewport", () => {
+    vi.stubGlobal("IntersectionObserver", makeIntersectionObserver(false));
+    render(
+      <CaseStudyHeroMedia
+        media={getCaseStudyMedia("covid")}
+        layout="embedded"
+        playback="active-scene"
+        isActive
+        showControls={false}
+      />
+    );
+    // Not intersecting → poster image stays, video is not mounted yet.
+    expect(screen.getByRole("img", { name: /covid-19 risk profiles/i })).toBeInTheDocument();
+    expect(document.querySelector("video")).toBeFalsy();
   });
 });

--- a/src/components/case-study/CaseStudyHeroMedia.tsx
+++ b/src/components/case-study/CaseStudyHeroMedia.tsx
@@ -51,6 +51,7 @@ export function CaseStudyHeroMedia({
   const videoRef = useRef<HTMLVideoElement>(null);
   const [lazyReady, setLazyReady] = useState(false);
   const [sceneVideoMounted, setSceneVideoMounted] = useState(false);
+  const [sceneInView, setSceneInView] = useState(false);
 
   const aspect = media.aspectRatio ?? "16/10";
   const frameClass = aspectClass[aspect];
@@ -81,12 +82,35 @@ export function CaseStudyHeroMedia({
     if (isActive) setSceneVideoMounted(true);
   }, [canUseVideo, playback, isActive]);
 
+  // For the embedded home "active-scene" playback, hold the video (and its
+  // poster fetch) until the frame is close to the viewport. The section sits
+  // below the fold, so this defers ~1.6 MB of media off the initial load.
+  useEffect(() => {
+    if (playback !== "active-scene") return;
+
+    const node = containerRef.current;
+    if (!node) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setSceneInView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "300px 0px" }
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [playback]);
+
   const videoEnabled =
     canUseVideo &&
     (playback === "lazy"
       ? lazyReady
       : playback === "active-scene"
-        ? sceneVideoMounted && isActive
+        ? sceneVideoMounted && sceneInView && isActive
         : false);
 
   const showPoster =
@@ -153,7 +177,7 @@ export function CaseStudyHeroMedia({
   );
 
   if (layout === "embedded") {
-    return <div className="absolute inset-0">{inner}</div>;
+    return <div ref={containerRef} className="absolute inset-0">{inner}</div>;
   }
 
   return (

--- a/src/components/sections/FeaturedWork.test.tsx
+++ b/src/components/sections/FeaturedWork.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import FeaturedWork from "./FeaturedWork";
+import type { ProjectItem } from "@/i18n/types";
+
+afterEach(() => {
+  cleanup();
+});
+
+const mockProject: ProjectItem = {
+  id: "01",
+  type: "hero",
+  context: "Client project",
+  category: "AI",
+  title: "EyeNet",
+  subtitle: "Pipeline that ships.",
+  problem: "Problem",
+  system: "System",
+  outcome: "Outcome",
+  role: "Lead engineer",
+  image: "/img/microservices.webp",
+  tags: ["ML"],
+  metrics: [{ value: "2x", label: "throughput" }],
+  links: [],
+  href: "/projects/eyenet",
+  caseStudy: "/projects/eyenet",
+};
+
+vi.mock("gsap", () => ({
+  default: {
+    registerPlugin: vi.fn(),
+    context: vi.fn().mockReturnValue({ revert: vi.fn() }),
+    set: vi.fn(),
+    fromTo: vi.fn(),
+    timeline: vi.fn(() => ({ to: vi.fn(), fromTo: vi.fn() })),
+  },
+}));
+
+vi.mock("gsap/ScrollTrigger", () => ({
+  ScrollTrigger: {
+    snapDirectional: vi.fn(() => () => 0),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    refresh: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useReducedMotion", () => ({
+  useReducedMotion: () => false,
+}));
+
+vi.mock("@/i18n/LanguageContext", () => ({
+  useLanguage: () => ({
+    language: "en",
+    t: {
+      work: {
+        title: "Selected work",
+        subtitle: "Projects that shipped.",
+        labelEvidence: "Evidence",
+        inspect: "Inspect",
+        projects: [mockProject],
+      },
+    },
+  }),
+}));
+
+vi.mock("./Scene", () => ({
+  Scene: ({ project }: { project: ProjectItem }) => <h3>{project.title}</h3>,
+  getAccent: () => ({ fg: "#6db88a", bg: "#101210", ink: "#ece8e0" }),
+  accentAlpha: (_c: string, a: number) => `rgba(0,0,0,${a})`,
+}));
+
+function stubMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => {},
+    }),
+  });
+}
+
+describe("FeaturedWork", () => {
+  beforeEach(() => {
+    stubMatchMedia(false);
+    Element.prototype.scrollTo = vi.fn();
+  });
+
+  it("renders the static header eyebrow at AA-safe ink", () => {
+    const { container } = render(<FeaturedWork />);
+    const eyebrow = container.querySelector(".mb-3 span");
+    expect(eyebrow).not.toBeNull();
+    expect(eyebrow?.getAttribute("style")).toContain("rgba(28, 28, 30, 0.65)");
+  });
+
+  it("renders the static header subtitle at AA-safe ink", () => {
+    const { container } = render(<FeaturedWork />);
+    const subtitle = container.querySelector('header p[class*="mt-4"]');
+    expect(subtitle).not.toBeNull();
+    expect(subtitle?.getAttribute("style")).toContain("rgba(28, 28, 30, 0.65)");
+  });
+
+  it("renders the static footer note at AA-safe charcoal", () => {
+    const { container } = render(<FeaturedWork />);
+    const note = container.querySelector('footer p[class*="text-charcoal/60"]');
+    expect(note).not.toBeNull();
+  });
+
+  it("labels the section with an h2 before project h3s in cinematic mode", async () => {
+    stubMatchMedia(true);
+    const { container } = render(<FeaturedWork />);
+
+    const h2 = await screen.findByRole("heading", { level: 2, name: /Selected work/i });
+    const firstH3 = container.querySelector("h3");
+    expect(firstH3).not.toBeNull();
+    expect(
+      h2.compareDocumentPosition(firstH3 as Node) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+});

--- a/src/components/sections/FeaturedWork.tsx
+++ b/src/components/sections/FeaturedWork.tsx
@@ -251,13 +251,18 @@ export default function FeaturedWork() {
 
   const renderHeader = (variant: "cinematic" | "static", inkOverride?: string, sceneIndex?: number) => {
     const ink = inkOverride ?? "#1c1c1e";
-    const inkSoft = `${ink}66`;
+    // inkSoft raised from 40% to 65% alpha so it clears WCAG AA (4.5:1) on the
+    // light paper background without flattening the header hierarchy.
+    const inkSoft = `${ink}A6`;
     const inkLine = `${ink}33`;
 
     if (variant === "cinematic" && sceneIndex !== undefined) {
       return (
         <header className="pointer-events-auto font-mono text-[9px] font-bold uppercase tracking-[0.32em]">
-          <span style={{ color: `${ink}40` }}>{t.work.title}</span>
+          {/* Section heading kept as a real h2 so the desktop heading order is h1 → h2 → h3 */}
+          <h2 className="inline font-mono text-[9px] font-bold uppercase tracking-[0.32em]" style={{ color: `${ink}40` }}>
+            {t.work.title}
+          </h2>
           <span style={{ color: `${ink}25` }}> · </span>
           <span style={{ color: `${ink}55` }}>
             {String(sceneIndex + 1).padStart(2, "0")}/{String(projects.length).padStart(2, "0")}
@@ -520,7 +525,7 @@ export default function FeaturedWork() {
               <p className="font-sans text-sm font-medium text-charcoal">
                 {language === "en" ? "More case studies in the archive" : "Más casos de estudio en el archivo"}
               </p>
-              <p className="font-sans text-xs text-charcoal/40">
+              <p className="font-sans text-xs text-charcoal/60">
                 {language === "en"
                   ? "12+ notebooks, experiments, and shipped systems."
                   : "12+ notebooks, experimentos y sistemas en producción."}

--- a/src/components/sections/Philosophy.test.tsx
+++ b/src/components/sections/Philosophy.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import Philosophy from "./Philosophy";
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock("gsap", () => ({
+  default: {
+    registerPlugin: vi.fn(),
+    context: vi.fn().mockReturnValue({ revert: vi.fn() }),
+    set: vi.fn(),
+    fromTo: vi.fn(),
+  },
+}));
+
+vi.mock("gsap/ScrollTrigger", () => ({
+  ScrollTrigger: {
+    create: vi.fn(() => ({ kill: vi.fn() })),
+  },
+}));
+
+vi.mock("@/hooks/useReducedMotion", () => ({
+  useReducedMotion: () => true,
+}));
+
+vi.mock("@/i18n/LanguageContext", () => ({
+  useLanguage: () => ({
+    t: {
+      philosophy: {
+        eyebrow: "Philosophy",
+        title: "How I build",
+        subtitle: "Principles that guide the work.",
+        quote: "Ship the pipeline, not the notebook.",
+        quoteBy: "— The build desk",
+        labelPrinciple: "Principle",
+        items: [
+          { title: "First principle", summary: "Summary one", description: "Description one" },
+          { title: "Second principle", summary: "Summary two", description: "Description two" },
+        ],
+        hintTap: "Tap a principle",
+        hintHover: "Hover a principle",
+        closure: "Keep it simple.",
+      },
+    },
+  }),
+}));
+
+describe("Philosophy", () => {
+  it("renders principle eyebrows at AA-safe opacity", () => {
+    const { container } = render(<Philosophy />);
+    const eyebrows = container.querySelectorAll('p[class*="mb-1.5"]');
+    expect(eyebrows.length).toBeGreaterThanOrEqual(2);
+    for (const el of eyebrows) {
+      expect(el.className).toContain("text-offwhite/50");
+    }
+  });
+
+  it("renders the interaction hint at AA-safe opacity", () => {
+    const { container } = render(<Philosophy />);
+    const hint = container.querySelector("p.mt-8");
+    expect(hint).not.toBeNull();
+    expect(hint?.className).toContain("text-offwhite/50");
+  });
+
+  it("derives the accessible name from visible content (no aria-label on panels)", () => {
+    const { container } = render(<Philosophy />);
+    const panels = container.querySelectorAll('article[role="button"]');
+    expect(panels.length).toBeGreaterThanOrEqual(2);
+    for (const panel of panels) {
+      expect(panel).not.toHaveAttribute("aria-label");
+    }
+    expect(screen.getByRole("button", { name: /First principle/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/Philosophy.tsx
+++ b/src/components/sections/Philosophy.tsx
@@ -197,7 +197,6 @@ export default function Philosophy() {
                 role="button"
                 tabIndex={0}
                 aria-expanded={isActive}
-                aria-label={item.title}
                 className="group rounded-2xl border border-white/10 bg-white/[0.03] px-6 py-5 transition-all duration-500 hover:border-white/16 focus:outline-none focus-visible:ring-2 focus-visible:ring-warm/35 md:px-8 md:py-6"
                 style={{
                   boxShadow: isActive ? `0 0 0 1px ${accentAlpha(accent, 0.2)} inset` : undefined,
@@ -205,7 +204,7 @@ export default function Philosophy() {
               >
                 <div className="flex items-start justify-between gap-4">
                   <div className="min-w-0 flex-1">
-                    <p className="mb-1.5 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/38">
+                    <p className="mb-1.5 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/50">
                       {labels.labelPrinciple} {caseNumber}
                     </p>
                     <h3 className="font-display text-xl tracking-tight text-offwhite md:text-2xl">
@@ -252,7 +251,7 @@ export default function Philosophy() {
           })}
         </div>
 
-        <p className="mt-8 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/28">
+        <p className="mt-8 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/50">
           {isCoarse ? labels.hintTap : labels.hintHover}
         </p>
 

--- a/src/components/sections/Stack.test.tsx
+++ b/src/components/sections/Stack.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import Stack from "./Stack";
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock("gsap", () => ({
+  default: {
+    registerPlugin: vi.fn(),
+    set: vi.fn(),
+    to: vi.fn(),
+    context: vi.fn().mockReturnValue({ revert: vi.fn() }),
+  },
+}));
+
+vi.mock("gsap/ScrollTrigger", () => ({
+  ScrollTrigger: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock("@gsap/react", () => ({
+  useGSAP: vi.fn(),
+}));
+
+vi.mock("@/hooks/useReducedMotion", () => ({
+  useReducedMotion: () => true,
+}));
+
+vi.mock("@/i18n/LanguageContext", () => ({
+  useLanguage: () => ({
+    language: "en",
+    t: {
+      stack: {
+        eyebrow: "Stack",
+        title: "Technical stack",
+        subtitle: "Tools I ship with.",
+        tools: ["Python", "SQL", "Next.js", "Power BI"],
+        bands: {
+          dataScience: "Data science",
+          infrastructure: "Infrastructure",
+          platform: "Platform",
+          core: "Core",
+        },
+        labelUsedIn: "Used in",
+        labelExploration: "Exploration",
+        projectOne: "project",
+        projectMany: "projects",
+        emptyTitle: "Select a tool",
+        emptyHint: "Pick a tool to see where it ships.",
+        hintTap: "Tap a tool",
+        hintHover: "Hover a tool",
+      },
+      work: {
+        projects: [],
+      },
+    },
+  }),
+}));
+
+describe("Stack", () => {
+  it("renders band labels at AA-safe opacity", () => {
+    const { container } = render(<Stack />);
+    const labels = container.querySelectorAll('span[style*="240, 234, 216, 0.6"]');
+    expect(labels.length).toBe(4);
+  });
+
+  it("renders the interaction hint at AA-safe opacity", () => {
+    const { container } = render(<Stack />);
+    const hint = container.querySelector("p.mt-8");
+    expect(hint).not.toBeNull();
+    expect(hint?.className).toContain("text-offwhite/50");
+  });
+
+  it("renders the empty-state hint at AA-safe opacity", () => {
+    const { container } = render(<Stack />);
+    const emptyHint = container.querySelector("p.max-w-lg");
+    expect(emptyHint).not.toBeNull();
+    expect(emptyHint?.className).toContain("text-offwhite/55");
+  });
+});

--- a/src/components/sections/Stack.tsx
+++ b/src/components/sections/Stack.tsx
@@ -254,7 +254,7 @@ export default function Stack() {
                   />
                   <span
                     className="font-mono text-[9px] font-bold uppercase tracking-[0.28em] transition-colors duration-500"
-                    style={{ color: isFocusedBand ? config.accent : "rgba(240,234,216,0.42)" }}
+                    style={{ color: isFocusedBand ? config.accent : "rgba(240,234,216,0.6)" }}
                   >
                     {config.name}
                   </span>
@@ -326,7 +326,7 @@ export default function Stack() {
           })}
         </div>
 
-        <p className="mt-8 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/28">
+        <p className="mt-8 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/50">
           {isCoarse ? labels.hintTap : labels.hintHover}
         </p>
 
@@ -354,7 +354,7 @@ export default function Stack() {
 
                 {activeProjects.length > 0 ? (
                   <>
-                    <p className="mb-4 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/38">
+                    <p className="mb-4 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/50">
                       {labels.labelUsedIn} · {projectCountLabel}
                     </p>
                     <div className="grid grid-cols-1 gap-2.5 md:grid-cols-2">
@@ -367,7 +367,7 @@ export default function Stack() {
                           className="group flex items-center justify-between gap-3 rounded-xl border border-offwhite/8 bg-offwhite/[0.02] px-4 py-3 transition-all hover:border-offwhite/16 hover:bg-offwhite/[0.04]"
                         >
                           <div className="min-w-0">
-                            <div className="font-mono text-[8px] font-bold uppercase tracking-[0.24em] text-offwhite/38">
+                            <div className="font-mono text-[8px] font-bold uppercase tracking-[0.24em] text-offwhite/50">
                               {project.context}
                             </div>
                             <div className="mt-0.5 font-sans text-sm font-medium text-offwhite/85 group-hover:text-white">
@@ -381,7 +381,7 @@ export default function Stack() {
                   </>
                 ) : (
                   <div className="flex flex-col gap-2">
-                    <p className="font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/38">
+                    <p className="font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/50">
                       {labels.labelExploration}
                     </p>
                     <p className="max-w-xl font-sans text-sm leading-relaxed text-offwhite/58 md:text-[15px]">
@@ -393,7 +393,7 @@ export default function Stack() {
             ) : (
               <div className="flex min-h-[120px] flex-col justify-center gap-2">
                 <p className="font-sans text-sm font-medium text-offwhite/50">{labels.emptyTitle}</p>
-                <p className="max-w-lg font-sans text-sm text-offwhite/38">{labels.emptyHint}</p>
+                <p className="max-w-lg font-sans text-sm text-offwhite/55">{labels.emptyHint}</p>
               </div>
             )}
           </div>

--- a/src/components/sections/Systems.test.tsx
+++ b/src/components/sections/Systems.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import Systems from "./Systems";
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock("gsap", () => ({
+  default: {
+    registerPlugin: vi.fn(),
+    context: vi.fn().mockReturnValue({ revert: vi.fn() }),
+    set: vi.fn(),
+    fromTo: vi.fn(),
+  },
+}));
+
+vi.mock("gsap/ScrollTrigger", () => ({
+  ScrollTrigger: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useReducedMotion", () => ({
+  useReducedMotion: () => true,
+}));
+
+vi.mock("@/i18n/LanguageContext", () => ({
+  useLanguage: () => ({
+    t: {
+      systems: {
+        eyebrow: "Systems",
+        title: "Systems & capabilities",
+        subtitle: "The layers I operate.",
+        labelCapability: "Capability",
+        labelUsedIn: "Used in",
+        railTop: "Data",
+        railBottom: "Product",
+        hintTap: "Tap a layer",
+        hintHover: "Hover a layer",
+        items: [
+          {
+            title: "Pipelines de Machine Learning",
+            summary: "Summary one",
+            description: "Description one",
+            usedIn: ["covid", "nyc"],
+            tags: ["ML", "ETL"],
+          },
+          {
+            title: "Ingeniería de Datos e Infraestructura",
+            summary: "Summary two",
+            description: "Description two",
+            usedIn: ["india"],
+            tags: ["SQL"],
+          },
+        ],
+      },
+    },
+  }),
+}));
+
+describe("Systems", () => {
+  it("derives the accessible name from visible content (no aria-label on panels)", () => {
+    const { container } = render(<Systems />);
+    const panels = container.querySelectorAll("div.layer-panel");
+    expect(panels.length).toBeGreaterThanOrEqual(2);
+    for (const panel of panels) {
+      expect(panel).toHaveAttribute("role", "button");
+      expect(panel).not.toHaveAttribute("aria-label");
+    }
+    expect(
+      screen.getByRole("button", { name: /Pipelines de Machine Learning/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/Systems.tsx
+++ b/src/components/sections/Systems.tsx
@@ -147,7 +147,6 @@ export default function Systems() {
         role="button"
         tabIndex={0}
         aria-expanded={isActive}
-        aria-label={cap.title}
         className="layer-panel group relative cursor-pointer rounded-2xl border border-white/10 bg-white/[0.03] transition-all duration-700 ease-out hover:border-white/18 focus:outline-none focus-visible:ring-2 focus-visible:ring-warm/40 focus-visible:ring-offset-2 focus-visible:ring-offset-charcoal"
         style={{
           transform: computeLayerTransform(idx),

--- a/src/components/ui/CommandPaletteLazy.test.tsx
+++ b/src/components/ui/CommandPaletteLazy.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { CommandPaletteProvider } from "@/hooks/CommandPaletteContext";
+import { CommandPaletteLazy } from "./CommandPaletteLazy";
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock("./CommandPalette", () => ({
+  CommandPalette: () => <div data-testid="palette">Command palette</div>,
+}));
+
+describe("CommandPaletteLazy", () => {
+  it("renders nothing while closed", () => {
+    render(
+      <CommandPaletteProvider>
+        <CommandPaletteLazy />
+      </CommandPaletteProvider>
+    );
+    expect(screen.queryByTestId("palette")).not.toBeInTheDocument();
+  });
+
+  it("mounts the palette module only when opened", async () => {
+    render(
+      <CommandPaletteProvider>
+        <CommandPaletteLazy />
+      </CommandPaletteProvider>
+    );
+    expect(screen.queryByTestId("palette")).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(await screen.findByTestId("palette")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/CommandPaletteLazy.tsx
+++ b/src/components/ui/CommandPaletteLazy.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { lazy, Suspense } from "react";
+import { useCommandPalette } from "@/hooks/CommandPaletteContext";
+
+// The palette is only useful after the user presses ⌘K/ctrl+K (or clicks the
+// navbar command button). Loading it lazily keeps gsap + the full command list
+// out of the initial bundle (Lighthouse: unused-javascript / bootup-time).
+const CommandPalette = lazy(() =>
+  import("./CommandPalette").then((mod) => ({ default: mod.CommandPalette }))
+);
+
+export function CommandPaletteLazy() {
+  const { open } = useCommandPalette();
+  if (!open) return null;
+  return (
+    <Suspense fallback={null}>
+      <CommandPalette />
+    </Suspense>
+  );
+}

--- a/src/components/ui/Marquee.test.tsx
+++ b/src/components/ui/Marquee.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import Marquee from "./Marquee";
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock("gsap", () => ({
+  default: {
+    to: vi.fn(),
+    set: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useReducedMotion", () => ({
+  useReducedMotion: () => true,
+}));
+
+vi.mock("@/i18n/LanguageContext", () => ({
+  useLanguage: () => ({
+    t: {
+      marquee: {
+        ariaLabel: "Tech marquee",
+        segments: [
+          { text: "Machine Learning", warm: false },
+          { text: "Data Engineering", warm: true },
+        ],
+      },
+    },
+  }),
+}));
+
+describe("Marquee", () => {
+  it("renders neutral segments at AA-safe opacity", () => {
+    render(<Marquee />);
+    const neutral = screen.getAllByText("Machine Learning");
+    expect(neutral.length).toBeGreaterThan(0);
+    for (const el of neutral) {
+      expect(el.className).toContain("text-offwhite/60");
+    }
+  });
+
+  it("keeps warm segments on the warm accent", () => {
+    render(<Marquee />);
+    const warm = screen.getAllByText("Data Engineering");
+    for (const el of warm) {
+      expect(el.className).toContain("text-warm/75");
+    }
+  });
+
+  it("exposes an accessible name", () => {
+    render(<Marquee />);
+    expect(screen.getByRole("marquee")).toHaveAttribute("aria-label", "Tech marquee");
+  });
+});

--- a/src/components/ui/Marquee.tsx
+++ b/src/components/ui/Marquee.tsx
@@ -56,7 +56,7 @@ export default function Marquee() {
               <span
                 key={`${dup}-${i}`}
                 className={`font-sans text-[10px] font-medium uppercase tracking-[0.22em] ${
-                  seg.warm ? "text-warm/75" : "text-offwhite/45"
+                  seg.warm ? "text-warm/75" : "text-offwhite/60"
                 }`}
               >
                 {seg.text}

--- a/src/components/ui/ProjectChat.test.tsx
+++ b/src/components/ui/ProjectChat.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { ProjectChat } from "./ProjectChat";
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock("gsap", () => ({
+  default: {
+    context: vi.fn().mockReturnValue({ revert: vi.fn() }),
+    set: vi.fn(),
+    to: vi.fn(),
+    fromTo: vi.fn(),
+    timeline: vi.fn(() => ({ to: vi.fn() })),
+    delayedCall: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useReducedMotion", () => ({
+  useReducedMotion: () => true,
+}));
+
+vi.mock("@/i18n/LanguageContext", () => ({
+  useLanguage: () => ({
+    language: "en",
+    t: {},
+  }),
+}));
+
+vi.mock("./ProjectChatPanel", () => ({
+  ProjectChatPanel: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div role="dialog" aria-label="Chat panel mock">
+        <span>Panel loaded</span>
+        <button type="button" onClick={onClose}>
+          Close
+        </button>
+      </div>
+    ) : null,
+}));
+
+describe("ProjectChat", () => {
+  it("renders the trigger button on load", () => {
+    render(<ProjectChat />);
+    expect(screen.getByRole("button", { name: /open portfolio chat/i })).toBeInTheDocument();
+    // Heavy panel (react-markdown + AI SDK) is not mounted until opened.
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("mounts the chat panel only after the trigger is clicked", async () => {
+    render(<ProjectChat />);
+    fireEvent.click(screen.getByRole("button", { name: /open portfolio chat/i }));
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("Panel loaded");
+  });
+});

--- a/src/components/ui/ProjectChat.tsx
+++ b/src/components/ui/ProjectChat.tsx
@@ -1,83 +1,44 @@
 "use client";
 
-import { useChat } from '@ai-sdk/react';
-import { Terminal, Maximize2, Minimize2, Send, User, X } from 'lucide-react';
-import { useState, useRef, useEffect, useMemo } from 'react';
-import ReactMarkdown from 'react-markdown';
+import { Terminal } from 'lucide-react';
+import { useRef, useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import gsap from 'gsap';
 import { useLanguage } from '@/i18n/LanguageContext';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 
-const CHAT_INPUT_ID = 'project-chat-input';
-const CHAT_TITLE_ID = 'project-chat-title';
-
-type ChatMessagePart = { type: string; text?: string };
-type ChatMessage = {
-  id: string;
-  role: string;
-  content?: string;
-  parts?: ChatMessagePart[];
-};
+// The chat panel carries react-markdown + the AI SDK data layer. It is loaded
+// only after the trigger is opened for the first time so those dependencies
+// stay off the initial bundle (Lighthouse: unused-javascript / bootup-time).
+const ProjectChatPanel = dynamic(
+  () => import("./ProjectChatPanel").then((mod) => ({ default: mod.ProjectChatPanel })),
+  { ssr: false, loading: () => null }
+);
 
 export function ProjectChat({ context: _context }: { context?: string }) {
   const [isOpen, setIsOpen] = useState(false);
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [input, setInput] = useState('');
-  const [greeting, setGreeting] = useState('');
-  const panelRef = useRef<HTMLDivElement>(null);
+  const [panelLoaded, setPanelLoaded] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const typingRef = useRef<HTMLSpanElement>(null);
   const cursorRef = useRef<HTMLSpanElement>(null);
   const { language } = useLanguage();
   const reduced = useReducedMotion();
 
-  const PROMPTS_EN = useMemo(() => [
+  const PROMPTS_EN = [
     "Ask about my work...",
     "What stack do you use?",
     "Show me your best project.",
     "What's your background?",
     "Are you available to hire?",
-  ], []);
+  ];
 
-  const PROMPTS_ES = useMemo(() => [
+  const PROMPTS_ES = [
     "Pregunta sobre mi trabajo...",
     "¿Qué tecnologías usas?",
     "Muéstrame tu mejor proyecto.",
     "¿Cuál es tu experiencia?",
     "¿Estás disponible para contratar?",
-  ], []);
-
-  const CHIP_LABELS_EN = useMemo(() => [
-    "What's your tech stack?",
-    "Best project?",
-    "Background & experience",
-    "Available to hire?",
-  ], []);
-
-  const CHIP_LABELS_ES = useMemo(() => [
-    "¿Qué tecnologías usas?",
-    "¿Mejor proyecto?",
-    "Experiencia y trayectoria",
-    "¿Disponible para contratar?",
-  ], []);
-
-  const { messages, sendMessage, status } = useChat() as {
-    messages?: ChatMessage[];
-    sendMessage: (opts: { text: string }) => void;
-    status?: string;
-  };
-  const isLoading = status === 'streaming' || status === 'submitted';
-
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-
-  // Time-of-day greeting
-  useEffect(() => {
-    const hour = new Date().getHours();
-    const isEs = language === 'es';
-    if (hour < 12) setGreeting(isEs ? 'Buenos días.' : 'Good morning.');
-    else if (hour < 18) setGreeting(isEs ? 'Buenas tardes.' : 'Good afternoon.');
-    else setGreeting(isEs ? 'Buenas noches.' : 'Good evening.');
-  }, [language]);
+  ];
 
   // Typewriter cycling animation using GSAP
   useEffect(() => {
@@ -143,82 +104,38 @@ export function ProjectChat({ context: _context }: { context?: string }) {
     });
 
     return () => ctx.revert();
-  }, [isOpen, language, PROMPTS_EN, PROMPTS_ES, reduced]);
+  }, [isOpen, language, reduced]);
 
-  // Main Toggle Animation
+  // Fade the trigger button out when the panel opens (button side only)
   useEffect(() => {
     const ctx = gsap.context(() => {
+      if (!buttonRef.current) return;
       if (isOpen) {
-        // Fade out button
-        if (buttonRef.current) {
-          if (reduced) {
-            gsap.set(buttonRef.current, { opacity: 0, y: 20, scale: 0.95, pointerEvents: 'none' });
-          } else {
-            gsap.to(buttonRef.current, {
-              opacity: 0,
-              y: 20,
-              scale: 0.95,
-              pointerEvents: 'none',
-              duration: 0.4,
-              ease: 'power2.inOut'
-            });
-          }
-        }
-        // Fade in panel
-        if (panelRef.current) {
-          if (reduced) {
-            gsap.set(panelRef.current, { opacity: 1, scale: 1, y: 0, pointerEvents: 'auto', display: 'flex' });
-          } else {
-            gsap.fromTo(panelRef.current,
-              { opacity: 0, scale: 0.9, y: 40 },
-              {
-                opacity: 1,
-                scale: 1,
-                y: 0,
-                duration: 0.7,
-                ease: 'expo.out',
-                pointerEvents: 'auto',
-                display: 'flex',
-                delay: 0.1
-              }
-            );
-          }
+        if (reduced) {
+          gsap.set(buttonRef.current, { opacity: 0, y: 20, scale: 0.95, pointerEvents: 'none' });
+        } else {
+          gsap.to(buttonRef.current, {
+            opacity: 0,
+            y: 20,
+            scale: 0.95,
+            pointerEvents: 'none',
+            duration: 0.4,
+            ease: 'power2.inOut'
+          });
         }
       } else {
-        // Fade out panel
-        if (panelRef.current) {
-          if (reduced) {
-            gsap.set(panelRef.current, { opacity: 0, scale: 0.95, y: 30, pointerEvents: 'none' });
-            if (panelRef.current) panelRef.current.style.display = 'none';
-          } else {
-            gsap.to(panelRef.current, {
-              opacity: 0,
-              scale: 0.95,
-              y: 30,
-              pointerEvents: 'none',
-              duration: 0.4,
-              ease: 'power2.inOut',
-              onComplete: () => {
-                if (panelRef.current) panelRef.current.style.display = 'none';
-              }
-            });
-          }
-        }
-        // Fade in button
-        if (buttonRef.current) {
-          if (reduced) {
-            gsap.set(buttonRef.current, { opacity: 1, y: 0, scale: 1, pointerEvents: 'auto' });
-          } else {
-            gsap.to(buttonRef.current, {
-              opacity: 1,
-              y: 0,
-              scale: 1,
-              pointerEvents: 'auto',
-              duration: 0.6,
-              ease: 'power3.out',
-              delay: 0.2
-            });
-          }
+        if (reduced) {
+          gsap.set(buttonRef.current, { opacity: 1, y: 0, scale: 1, pointerEvents: 'auto' });
+        } else {
+          gsap.to(buttonRef.current, {
+            opacity: 1,
+            y: 0,
+            scale: 1,
+            pointerEvents: 'auto',
+            duration: 0.6,
+            ease: 'power3.out',
+            delay: 0.2
+          });
         }
       }
     });
@@ -241,42 +158,10 @@ export function ProjectChat({ context: _context }: { context?: string }) {
     );
   }, [reduced]);
 
-  useEffect(() => {
-    if (messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
-    }
-  }, [messages]);
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!input.trim() || isLoading) return;
-    sendMessage({ text: input.trim() });
-    setInput('');
+  const handleOpen = () => {
+    setPanelLoaded(true);
+    setIsOpen(true);
   };
-
-  const handleChipClick = (prompt: string) => {
-    if (isLoading) return;
-    sendMessage({ text: prompt });
-  };
-
-  const visibleMessages = (messages ?? []).filter((m) => m.role !== 'system');
-  const hasMessages = visibleMessages.length > 0;
-
-  const chipLabels = language === 'es' ? CHIP_LABELS_ES : CHIP_LABELS_EN;
-  const chipPrompts = language === 'es' ? PROMPTS_ES : PROMPTS_EN;
-
-  const emptyGreetingLine1 = language === 'es' ? '> Sistema listo.' : '> System ready.';
-  const emptyGreetingLine2 = language === 'es'
-    ? '> Pregúntame sobre pipelines, arquitectura o disponibilidad.'
-    : '> Ask me about pipelines, architecture, or availability.';
-  const inputHint = language === 'es'
-    ? 'Presiona Enter para enviar · Shift+Enter para nueva línea'
-    : 'Press Enter to send · Shift+Enter for new line';
-  const footerLabel = language === 'es'
-    ? 'Powered by DeepSeek-V3 · Respuestas sintéticas'
-    : 'Powered by DeepSeek-V3 · Responses are synthetic';
-  const ariaChatLabel = language === 'es' ? 'Chat sobre el trabajo de Diego' : "Chat about Diego's work";
-  const srInputLabel = language === 'es' ? 'Pregunta sobre mi trabajo' : 'Ask about my work';
 
   return (
     <>
@@ -284,7 +169,7 @@ export function ProjectChat({ context: _context }: { context?: string }) {
       <button
         ref={buttonRef}
         type="button"
-        onClick={() => setIsOpen(true)}
+        onClick={handleOpen}
         aria-label="Open portfolio chat"
         style={{ opacity: 0 }}
         className="project-chat-trigger fixed z-50 inset-x-0 mx-auto w-fit bottom-[max(1.5rem,env(safe-area-inset-bottom))] flex min-h-[52px] items-center gap-4 rounded-full border border-white/10 bg-charcoal/80 backdrop-blur-xl pl-2 pr-8 py-2 font-mono text-[12px] font-medium text-offwhite shadow-[0_20px_50px_rgba(0,0,0,0.3),inset_0_1px_1px_rgba(255,255,255,0.1)] hover:shadow-[0_20px_60px_rgba(201,125,53,0.3),inset_0_1px_1px_rgba(255,255,255,0.2)] transition-all duration-500 hover:border-warm/50 hover:scale-[1.02] group spring-press"
@@ -312,194 +197,14 @@ export function ProjectChat({ context: _context }: { context?: string }) {
         </span>
       </button>
 
-      {/* Chat Panel - Always Mounted but hidden via GSAP */}
-      <div
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={CHAT_TITLE_ID}
-        aria-label={ariaChatLabel}
-        style={{ opacity: 0, display: 'none', pointerEvents: 'none' }}
-        className={`fixed z-50 flex flex-col bg-charcoal/95 backdrop-blur-2xl shadow-[0_30px_100px_rgba(0,0,0,0.5)] border border-white/10 overflow-hidden
-        ${isExpanded
-          ? 'inset-0 rounded-none border-0 pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)]'
-          : 'rounded-2xl inset-x-0 mx-auto bottom-[max(1.5rem,env(safe-area-inset-bottom))] h-[min(600px,80vh)] w-[min(450px,calc(100vw-2rem))]'
-        }`}
-      >
-        {/* Top accent bar */}
-        <div
-          className="absolute top-0 left-0 right-0 h-[2px] pointer-events-none z-20"
-          style={{ background: 'linear-gradient(90deg, transparent 0%, rgba(201,125,53,0.6) 20%, rgba(201,125,53,0.8) 50%, rgba(201,125,53,0.6) 80%, transparent 100%)' }}
-          aria-hidden
+      {panelLoaded && (
+        <ProjectChatPanel
+          open={isOpen}
+          language={language}
+          reduced={reduced}
+          onClose={() => setIsOpen(false)}
         />
-
-        {/* Subtle scan lines across panel */}
-        <div
-          className="absolute inset-0 pointer-events-none z-0"
-          style={{
-            backgroundImage: 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(255,255,255,0.012) 2px, rgba(255,255,255,0.012) 4px)',
-          }}
-          aria-hidden
-        />
-
-        {/* Terminal title bar */}
-        <div className="relative z-10 flex items-center justify-between border-b border-white/10 px-6 py-4 bg-charcoal/60">
-          <div className="flex items-center gap-3">
-            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-warm/20 border border-warm/30">
-              <Terminal className="h-4 w-4 text-warm" aria-hidden />
-            </div>
-            <div className="flex flex-col">
-              <span id={CHAT_TITLE_ID} className="font-mono text-xs font-bold uppercase tracking-[0.15em] text-offwhite">
-                DV-OS Terminal
-              </span>
-              <span className="text-[10px] text-offwhite/40 uppercase tracking-widest font-mono">
-                System Console v2.0
-              </span>
-            </div>
-          </div>
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => setIsExpanded(!isExpanded)}
-              className="flex min-w-[44px] min-h-[44px] items-center justify-center rounded-full text-offwhite/40 transition-all hover:text-offwhite hover:bg-white/5"
-              aria-label={isExpanded ? 'Minimize chat' : 'Expand chat'}
-            >
-              {isExpanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setIsOpen(false);
-                setIsExpanded(false);
-              }}
-              className="flex min-w-[44px] min-h-[44px] items-center justify-center rounded-full text-offwhite/40 transition-all hover:text-offwhite hover:bg-white/5"
-              aria-label="Close chat"
-            >
-              <X className="h-4 w-4" aria-hidden />
-            </button>
-          </div>
-        </div>
-
-        <div
-          role="log"
-          aria-label="Chat messages"
-          className={`relative z-10 flex-1 space-y-6 overflow-y-auto px-6 py-8 scrollbar-thin scrollbar-thumb-white/10 ${isExpanded ? 'mx-auto w-full max-w-3xl' : ''}`}
-        >
-          {!hasMessages && (
-            <div className="mt-12 flex flex-col items-center gap-5 px-4">
-              <div className="h-px w-12 bg-warm/30"></div>
-              <p className="font-garamond text-xl italic text-offwhite/90">{greeting}</p>
-
-              {/* Terminal-style empty state */}
-              <div className="flex flex-col items-start gap-1 font-mono text-[11px] text-offwhite/50 leading-relaxed max-w-[260px]">
-                <span>{emptyGreetingLine1}</span>
-                <span className="flex items-center">
-                  {emptyGreetingLine2}
-                  <span className="ml-1 inline-block w-[2px] h-[12px] bg-warm rounded-full animate-pulse" aria-hidden />
-                </span>
-              </div>
-
-              {/* Suggestion chips */}
-              <div className="flex flex-wrap justify-center gap-2 mt-1 max-w-[320px]">
-                {chipLabels.map((label, i) => (
-                  <button
-                    key={label}
-                    type="button"
-                    onClick={() => handleChipClick(chipPrompts[i])}
-                    className="font-mono text-[11px] px-3 py-1.5 rounded-full border border-white/10 text-offwhite/50 hover:text-offwhite hover:border-warm/40 hover:bg-warm/10 transition-all duration-300"
-                  >
-                    {label}
-                  </button>
-                ))}
-              </div>
-
-              <div className="h-px w-12 bg-warm/30"></div>
-            </div>
-          )}
-
-          {visibleMessages.map((m) => (
-            <div key={m.id} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-              <div
-                className={`max-w-[85%] group ${m.role === 'user' ? 'items-end' : 'items-start'}`}
-              >
-                <div className={`flex items-center gap-2 mb-2 opacity-30 group-hover:opacity-60 transition-opacity ${m.role === 'user' ? 'flex-row-reverse' : ''}`}>
-                  <div className="h-4 w-4 rounded-full bg-white/10 flex items-center justify-center">
-                    {m.role === 'user' ? <User className="h-2.5 w-2.5 text-offwhite" aria-hidden /> : <Terminal className="h-2.5 w-2.5 text-warm" aria-hidden />}
-                  </div>
-                  <span className="font-mono text-[9px] uppercase tracking-widest text-offwhite">{m.role}</span>
-                </div>
-
-                <div className={`rounded-2xl px-4 py-3 font-sans text-sm leading-relaxed ${
-                  m.role === 'user'
-                    ? 'bg-warm text-charcoal font-medium shadow-[0_10px_30px_rgba(201,125,53,0.25)]'
-                    : 'bg-white/5 text-offwhite/90 border border-white/10 backdrop-blur-sm border-l-[2px] border-l-[var(--color-accent)]/30'
-                }`}>
-                  <ReactMarkdown
-                    components={{
-                      p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-                      ul: ({ children }) => <ul className="mb-2 list-disc space-y-1 pl-4 opacity-90">{children}</ul>,
-                      ol: ({ children }) => <ol className="mb-2 list-decimal space-y-1 pl-4 opacity-90">{children}</ol>,
-                      li: ({ children }) => <li>{children}</li>,
-                      strong: ({ children }) => <strong className="font-bold text-white">{children}</strong>,
-                      code: ({ children }) => <code className="rounded bg-white/10 px-1.5 py-0.5 font-mono text-[11px] text-warm-light">{children}</code>,
-                    }}
-                  >
-                    {(m.parts ?? []).filter((p) => p.type === 'text').map((p) => p.text).join('') || m.content || ''}
-                  </ReactMarkdown>
-                </div>
-              </div>
-            </div>
-          ))}
-
-          {isLoading && (
-            <div className="flex justify-start">
-              <div className="flex items-center gap-1.5 rounded-full bg-white/5 border border-white/10 px-4 py-2.5">
-                <span className="chat-typing-dot h-1.5 w-1.5 rounded-full bg-warm" style={{ animationDelay: '0ms' }} />
-                <span className="chat-typing-dot h-1.5 w-1.5 rounded-full bg-warm" style={{ animationDelay: '150ms' }} />
-                <span className="chat-typing-dot h-1.5 w-1.5 rounded-full bg-warm" style={{ animationDelay: '300ms' }} />
-              </div>
-            </div>
-          )}
-          <div ref={messagesEndRef} />
-        </div>
-
-        <div className={`relative z-10 p-6 ${isExpanded ? 'mx-auto w-full max-w-3xl' : ''}`}>
-          <form
-            onSubmit={handleSubmit}
-            className="relative flex items-center"
-          >
-            <label htmlFor={CHAT_INPUT_ID} className="sr-only">
-              {srInputLabel}
-            </label>
-            <input
-              id={CHAT_INPUT_ID}
-              type="text"
-              className="w-full h-14 rounded-xl border border-white/10 bg-white/5 pl-5 pr-16 text-offwhite placeholder:text-offwhite/20 focus:outline-none focus:border-warm/50 focus:bg-white/10 transition-all duration-300"
-              value={input}
-              placeholder={language === 'es' ? 'Escribe tu pregunta...' : 'Type your question...'}
-              onChange={(e) => setInput(e.target.value)}
-              disabled={isLoading}
-              autoComplete="off"
-            />
-            <button
-              type="submit"
-              disabled={isLoading || !input.trim()}
-              className="absolute right-2 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-warm text-charcoal hover:scale-105 active:scale-95 disabled:opacity-30 disabled:grayscale transition-all duration-300 shadow-lg shadow-warm/20"
-              aria-label="Send message"
-            >
-              <Send className="h-4 w-4" aria-hidden />
-            </button>
-          </form>
-          <div className="mt-2 flex flex-col items-center gap-1">
-            <p className="text-center font-mono text-[9px] uppercase tracking-[0.15em] text-offwhite/25">
-              {inputHint}
-            </p>
-            <p className="text-center font-mono text-[9px] uppercase tracking-[0.2em] text-offwhite/20">
-              {footerLabel}
-            </p>
-          </div>
-        </div>
-      </div>
+      )}
     </>
   );
 }

--- a/src/components/ui/ProjectChatPanel.tsx
+++ b/src/components/ui/ProjectChatPanel.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useChat } from '@ai-sdk/react';
+import { Terminal, Maximize2, Minimize2, Send, User, X } from 'lucide-react';
+import { useState, useRef, useEffect, useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import gsap from 'gsap';
+
+const CHAT_INPUT_ID = 'project-chat-input';
+const CHAT_TITLE_ID = 'project-chat-title';
+
+type ChatMessagePart = { type: string; text?: string };
+type ChatMessage = {
+  id: string;
+  role: string;
+  content?: string;
+  parts?: ChatMessagePart[];
+};
+
+interface ProjectChatPanelProps {
+  open: boolean;
+  language: string;
+  reduced: boolean;
+  onClose: () => void;
+}
+
+export function ProjectChatPanel({ open, language, reduced, onClose }: ProjectChatPanelProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [input, setInput] = useState('');
+  const [greeting, setGreeting] = useState('');
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const PROMPTS_EN = useMemo(() => [
+    "Ask about my work...",
+    "What stack do you use?",
+    "Show me your best project.",
+    "What's your background?",
+    "Are you available to hire?",
+  ], []);
+
+  const PROMPTS_ES = useMemo(() => [
+    "Pregunta sobre mi trabajo...",
+    "¿Qué tecnologías usas?",
+    "Muéstrame tu mejor proyecto.",
+    "¿Cuál es tu experiencia?",
+    "¿Estás disponible para contratar?",
+  ], []);
+
+  const CHIP_LABELS_EN = useMemo(() => [
+    "What's your tech stack?",
+    "Best project?",
+    "Background & experience",
+    "Available to hire?",
+  ], []);
+
+  const CHIP_LABELS_ES = useMemo(() => [
+    "¿Qué tecnologías usas?",
+    "¿Mejor proyecto?",
+    "Experiencia y trayectoria",
+    "¿Disponible para contratar?",
+  ], []);
+
+  const { messages, sendMessage, status } = useChat() as {
+    messages?: ChatMessage[];
+    sendMessage: (opts: { text: string }) => void;
+    status?: string;
+  };
+  const isLoading = status === 'streaming' || status === 'submitted';
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Time-of-day greeting
+  useEffect(() => {
+    const hour = new Date().getHours();
+    const isEs = language === 'es';
+    if (hour < 12) setGreeting(isEs ? 'Buenos días.' : 'Good morning.');
+    else if (hour < 18) setGreeting(isEs ? 'Buenas tardes.' : 'Good afternoon.');
+    else setGreeting(isEs ? 'Buenas noches.' : 'Good evening.');
+  }, [language]);
+
+  // Main Toggle Animation (panel side)
+  useEffect(() => {
+    const ctx = gsap.context(() => {
+      if (open) {
+        if (panelRef.current) {
+          if (reduced) {
+            gsap.set(panelRef.current, { opacity: 1, scale: 1, y: 0, pointerEvents: 'auto', display: 'flex' });
+          } else {
+            gsap.fromTo(panelRef.current,
+              { opacity: 0, scale: 0.9, y: 40 },
+              {
+                opacity: 1,
+                scale: 1,
+                y: 0,
+                duration: 0.7,
+                ease: 'expo.out',
+                pointerEvents: 'auto',
+                display: 'flex',
+                delay: 0.1
+              }
+            );
+          }
+        }
+      } else {
+        if (panelRef.current) {
+          if (reduced) {
+            gsap.set(panelRef.current, { opacity: 0, scale: 0.95, y: 30, pointerEvents: 'none' });
+            if (panelRef.current) panelRef.current.style.display = 'none';
+          } else {
+            gsap.to(panelRef.current, {
+              opacity: 0,
+              scale: 0.95,
+              y: 30,
+              pointerEvents: 'none',
+              duration: 0.4,
+              ease: 'power2.inOut',
+              onComplete: () => {
+                if (panelRef.current) panelRef.current.style.display = 'none';
+              }
+            });
+          }
+        }
+      }
+    });
+
+    return () => ctx.revert();
+  }, [open, reduced]);
+
+  useEffect(() => {
+    if (messagesEndRef.current) {
+      messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || isLoading) return;
+    sendMessage({ text: input.trim() });
+    setInput('');
+  };
+
+  const handleChipClick = (prompt: string) => {
+    if (isLoading) return;
+    sendMessage({ text: prompt });
+  };
+
+  const visibleMessages = (messages ?? []).filter((m) => m.role !== 'system');
+  const hasMessages = visibleMessages.length > 0;
+
+  const chipLabels = language === 'es' ? CHIP_LABELS_ES : CHIP_LABELS_EN;
+  const chipPrompts = language === 'es' ? PROMPTS_ES : PROMPTS_EN;
+
+  const emptyGreetingLine1 = language === 'es' ? '> Sistema listo.' : '> System ready.';
+  const emptyGreetingLine2 = language === 'es'
+    ? '> Pregúntame sobre pipelines, arquitectura o disponibilidad.'
+    : '> Ask me about pipelines, architecture, or availability.';
+  const inputHint = language === 'es'
+    ? 'Presiona Enter para enviar · Shift+Enter para nueva línea'
+    : 'Press Enter to send · Shift+Enter for new line';
+  const footerLabel = language === 'es'
+    ? 'Powered by DeepSeek-V3 · Respuestas sintéticas'
+    : 'Powered by DeepSeek-V3 · Responses are synthetic';
+  const ariaChatLabel = language === 'es' ? 'Chat sobre el trabajo de Diego' : "Chat about Diego's work";
+  const srInputLabel = language === 'es' ? 'Pregunta sobre mi trabajo' : 'Ask about my work';
+
+  return (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={CHAT_TITLE_ID}
+      aria-label={ariaChatLabel}
+      style={{ opacity: 0, display: 'none', pointerEvents: 'none' }}
+      className={`fixed z-50 flex flex-col bg-charcoal/95 backdrop-blur-2xl shadow-[0_30px_100px_rgba(0,0,0,0.5)] border border-white/10 overflow-hidden
+      ${isExpanded
+        ? 'inset-0 rounded-none border-0 pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)]'
+        : 'rounded-2xl inset-x-0 mx-auto bottom-[max(1.5rem,env(safe-area-inset-bottom))] h-[min(600px,80vh)] w-[min(450px,calc(100vw-2rem))]'
+      }`}
+    >
+      {/* Top accent bar */}
+      <div
+        className="absolute top-0 left-0 right-0 h-[2px] pointer-events-none z-20"
+        style={{ background: 'linear-gradient(90deg, transparent 0%, rgba(201,125,53,0.6) 20%, rgba(201,125,53,0.8) 50%, rgba(201,125,53,0.6) 80%, transparent 100%)' }}
+        aria-hidden
+      />
+
+      {/* Subtle scan lines across panel */}
+      <div
+        className="absolute inset-0 pointer-events-none z-0"
+        style={{
+          backgroundImage: 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(255,255,255,0.012) 2px, rgba(255,255,255,0.012) 4px)',
+        }}
+        aria-hidden
+      />
+
+      {/* Terminal title bar */}
+      <div className="relative z-10 flex items-center justify-between border-b border-white/10 px-6 py-4 bg-charcoal/60">
+        <div className="flex items-center gap-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-warm/20 border border-warm/30">
+            <Terminal className="h-4 w-4 text-warm" aria-hidden />
+          </div>
+          <div className="flex flex-col">
+            <span id={CHAT_TITLE_ID} className="font-mono text-xs font-bold uppercase tracking-[0.15em] text-offwhite">
+              DV-OS Terminal
+            </span>
+            <span className="text-[10px] text-offwhite/40 uppercase tracking-widest font-mono">
+              System Console v2.0
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="flex min-w-[44px] min-h-[44px] items-center justify-center rounded-full text-offwhite/40 transition-all hover:text-offwhite hover:bg-white/5"
+            aria-label={isExpanded ? 'Minimize chat' : 'Expand chat'}
+          >
+            {isExpanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setIsExpanded(false);
+              onClose();
+            }}
+            className="flex min-w-[44px] min-h-[44px] items-center justify-center rounded-full text-offwhite/40 transition-all hover:text-offwhite hover:bg-white/5"
+            aria-label="Close chat"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+      </div>
+
+      <div
+        role="log"
+        aria-label="Chat messages"
+        className={`relative z-10 flex-1 space-y-6 overflow-y-auto px-6 py-8 scrollbar-thin scrollbar-thumb-white/10 ${isExpanded ? 'mx-auto w-full max-w-3xl' : ''}`}
+      >
+        {!hasMessages && (
+          <div className="mt-12 flex flex-col items-center gap-5 px-4">
+            <div className="h-px w-12 bg-warm/30"></div>
+            <p className="font-garamond text-xl italic text-offwhite/90">{greeting}</p>
+
+            {/* Terminal-style empty state */}
+            <div className="flex flex-col items-start gap-1 font-mono text-[11px] text-offwhite/50 leading-relaxed max-w-[260px]">
+              <span>{emptyGreetingLine1}</span>
+              <span className="flex items-center">
+                {emptyGreetingLine2}
+                <span className="ml-1 inline-block w-[2px] h-[12px] bg-warm rounded-full animate-pulse" aria-hidden />
+              </span>
+            </div>
+
+            {/* Suggestion chips */}
+            <div className="flex flex-wrap justify-center gap-2 mt-1 max-w-[320px]">
+              {chipLabels.map((label, i) => (
+                <button
+                  key={label}
+                  type="button"
+                  onClick={() => handleChipClick(chipPrompts[i])}
+                  className="font-mono text-[11px] px-3 py-1.5 rounded-full border border-white/10 text-offwhite/50 hover:text-offwhite hover:border-warm/40 hover:bg-warm/10 transition-all duration-300"
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            <div className="h-px w-12 bg-warm/30"></div>
+          </div>
+        )}
+
+        {visibleMessages.map((m) => (
+          <div key={m.id} className={`flex ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+            <div
+              className={`max-w-[85%] group ${m.role === 'user' ? 'items-end' : 'items-start'}`}
+            >
+              <div className={`flex items-center gap-2 mb-2 opacity-30 group-hover:opacity-60 transition-opacity ${m.role === 'user' ? 'flex-row-reverse' : ''}`}>
+                <div className="h-4 w-4 rounded-full bg-white/10 flex items-center justify-center">
+                  {m.role === 'user' ? <User className="h-2.5 w-2.5 text-offwhite" aria-hidden /> : <Terminal className="h-2.5 w-2.5 text-warm" aria-hidden />}
+                </div>
+                <span className="font-mono text-[9px] uppercase tracking-widest text-offwhite">{m.role}</span>
+              </div>
+
+              <div className={`rounded-2xl px-4 py-3 font-sans text-sm leading-relaxed ${
+                m.role === 'user'
+                  ? 'bg-warm text-charcoal font-medium shadow-[0_10px_30px_rgba(201,125,53,0.25)]'
+                  : 'bg-white/5 text-offwhite/90 border border-white/10 backdrop-blur-sm border-l-[2px] border-l-[var(--color-accent)]/30'
+              }`}>
+                <ReactMarkdown
+                  components={{
+                    p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+                    ul: ({ children }) => <ul className="mb-2 list-disc space-y-1 pl-4 opacity-90">{children}</ul>,
+                    ol: ({ children }) => <ol className="mb-2 list-decimal space-y-1 pl-4 opacity-90">{children}</ol>,
+                    li: ({ children }) => <li>{children}</li>,
+                    strong: ({ children }) => <strong className="font-bold text-white">{children}</strong>,
+                    code: ({ children }) => <code className="rounded bg-white/10 px-1.5 py-0.5 font-mono text-[11px] text-warm-light">{children}</code>,
+                  }}
+                >
+                  {(m.parts ?? []).filter((p) => p.type === 'text').map((p) => p.text).join('') || m.content || ''}
+                </ReactMarkdown>
+              </div>
+            </div>
+          </div>
+        ))}
+
+        {isLoading && (
+          <div className="flex justify-start">
+            <div className="flex items-center gap-1.5 rounded-full bg-white/5 border border-white/10 px-4 py-2.5">
+              <span className="chat-typing-dot h-1.5 w-1.5 rounded-full bg-warm" style={{ animationDelay: '0ms' }} />
+              <span className="chat-typing-dot h-1.5 w-1.5 rounded-full bg-warm" style={{ animationDelay: '150ms' }} />
+              <span className="chat-typing-dot h-1.5 w-1.5 rounded-full bg-warm" style={{ animationDelay: '300ms' }} />
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div className={`relative z-10 p-6 ${isExpanded ? 'mx-auto w-full max-w-3xl' : ''}`}>
+        <form
+          onSubmit={handleSubmit}
+          className="relative flex items-center"
+        >
+          <label htmlFor={CHAT_INPUT_ID} className="sr-only">
+            {srInputLabel}
+          </label>
+          <input
+            id={CHAT_INPUT_ID}
+            type="text"
+            className="w-full h-14 rounded-xl border border-white/10 bg-white/5 pl-5 pr-16 text-offwhite placeholder:text-offwhite/20 focus:outline-none focus:border-warm/50 focus:bg-white/10 transition-all duration-300"
+            value={input}
+            placeholder={language === 'es' ? 'Escribe tu pregunta...' : 'Type your question...'}
+            onChange={(e) => setInput(e.target.value)}
+            disabled={isLoading}
+            autoComplete="off"
+          />
+          <button
+            type="submit"
+            disabled={isLoading || !input.trim()}
+            className="absolute right-2 min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-warm text-charcoal hover:scale-105 active:scale-95 disabled:opacity-30 disabled:grayscale transition-all duration-300 shadow-lg shadow-warm/20"
+            aria-label="Send message"
+          >
+            <Send className="h-4 w-4" aria-hidden />
+          </button>
+        </form>
+        <div className="mt-2 flex flex-col items-center gap-1">
+          <p className="text-center font-mono text-[9px] uppercase tracking-[0.15em] text-offwhite/25">
+            {inputHint}
+          </p>
+          <p className="text-center font-mono text-[9px] uppercase tracking-[0.2em] text-offwhite/20">
+            {footerLabel}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/WebGLHeroCanvas.test.tsx
+++ b/src/components/ui/WebGLHeroCanvas.test.tsx
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { cleanup, render } from "@testing-library/react";
 import WebGLHeroCanvas from "./WebGLHeroCanvas";
 
 vi.mock("@/hooks/useReducedMotion", () => ({
   useReducedMotion: () => false,
 }));
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("WebGLHeroCanvas", () => {
   it("renders a canvas element", () => {

--- a/src/components/ui/WebGLHeroCanvas.tsx
+++ b/src/components/ui/WebGLHeroCanvas.tsx
@@ -129,102 +129,126 @@ export default function WebGLHeroCanvas({ className }: { className?: string }) {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const gl = canvas.getContext("webgl", { alpha: false, antialias: false });
-    if (!gl) return;
+    let cancelled = false;
+    let dispose: (() => void) | undefined;
 
-    // Compile shaders
-    const vs = createShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
-    const fs = createShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
-    if (!vs || !fs) return;
+    const init = () => {
+      if (cancelled) return;
 
-    const program = createProgram(gl, vs, fs);
-    if (!program) return;
+      const gl = canvas.getContext("webgl", { alpha: false, antialias: false });
+      if (!gl) return;
 
-    gl.useProgram(program);
+      // Compile shaders
+      const vs = createShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER);
+      const fs = createShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER);
+      if (!vs || !fs) return;
 
-    // Full-screen quad
-    const buffer = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
-      -1, -1, 1, -1, -1, 1,
-      -1, 1, 1, -1, 1, 1,
-    ]), gl.STATIC_DRAW);
+      const program = createProgram(gl, vs, fs);
+      if (!program) return;
 
-    const posLoc = gl.getAttribLocation(program, "a_position");
-    gl.enableVertexAttribArray(posLoc);
-    gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
+      gl.useProgram(program);
 
-    // Uniforms
-    const uTime = gl.getUniformLocation(program, "u_time");
-    const uMouse = gl.getUniformLocation(program, "u_mouse");
-    const uResolution = gl.getUniformLocation(program, "u_resolution");
+      // Full-screen quad
+      const buffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+        -1, -1, 1, -1, -1, 1,
+        -1, 1, 1, -1, 1, 1,
+      ]), gl.STATIC_DRAW);
 
-    // Resize handler
-    const resize = () => {
-      const dpr = Math.min(window.devicePixelRatio, 2);
-      const w = canvas.clientWidth;
-      const h = canvas.clientHeight;
-      canvas.width = w * dpr;
-      canvas.height = h * dpr;
-      gl.viewport(0, 0, canvas.width, canvas.height);
-    };
-    resize();
-    window.addEventListener("resize", resize);
+      const posLoc = gl.getAttribLocation(program, "a_position");
+      gl.enableVertexAttribArray(posLoc);
+      gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
 
-    // Visibility change — pause when tab inactive
-    let startTime = performance.now();
-    let paused = false;
-    const handleVisibility = () => {
-      paused = document.hidden;
-      if (!paused) startTime = performance.now() - (rafRef.current * 16);
-    };
-    document.addEventListener("visibilitychange", handleVisibility);
+      // Uniforms
+      const uTime = gl.getUniformLocation(program, "u_time");
+      const uMouse = gl.getUniformLocation(program, "u_mouse");
+      const uResolution = gl.getUniformLocation(program, "u_resolution");
 
-    // Context lost/restore
-    const handleContextLost = (e: Event) => {
-      e.preventDefault();
-      cancelAnimationFrame(rafRef.current);
-    };
-    const handleContextRestored = () => {
-      // Re-init would happen here; for simplicity, just restart loop
-      startTime = performance.now();
-    };
-    canvas.addEventListener("webglcontextlost", handleContextLost);
-    canvas.addEventListener("webglcontextrestored", handleContextRestored);
+      // Resize handler
+      const resize = () => {
+        const dpr = Math.min(window.devicePixelRatio, 2);
+        const w = canvas.clientWidth;
+        const h = canvas.clientHeight;
+        canvas.width = w * dpr;
+        canvas.height = h * dpr;
+        gl.viewport(0, 0, canvas.width, canvas.height);
+      };
+      resize();
+      window.addEventListener("resize", resize);
 
-    // Render loop
-    const renderLoop = () => {
-      if (paused) {
+      // Visibility change — pause when tab inactive
+      let startTime = performance.now();
+      let paused = false;
+      const handleVisibility = () => {
+        paused = document.hidden;
+        if (!paused) startTime = performance.now() - (rafRef.current * 16);
+      };
+      document.addEventListener("visibilitychange", handleVisibility);
+
+      // Context lost/restore
+      const handleContextLost = (e: Event) => {
+        e.preventDefault();
+        cancelAnimationFrame(rafRef.current);
+      };
+      const handleContextRestored = () => {
+        // Re-init would happen here; for simplicity, just restart loop
+        startTime = performance.now();
+      };
+      canvas.addEventListener("webglcontextlost", handleContextLost);
+      canvas.addEventListener("webglcontextrestored", handleContextRestored);
+
+      // Render loop
+      const renderLoop = () => {
+        if (paused) {
+          rafRef.current = requestAnimationFrame(renderLoop);
+          return;
+        }
+
+        const time = (performance.now() - startTime) / 1000;
+
+        // Lerp mouse for smoothness
+        lerpMouseRef.current.x += (mouseRef.current.x - lerpMouseRef.current.x) * 0.05;
+        lerpMouseRef.current.y += (mouseRef.current.y - lerpMouseRef.current.y) * 0.05;
+
+        gl.uniform1f(uTime, time);
+        gl.uniform2f(uMouse, lerpMouseRef.current.x, lerpMouseRef.current.y);
+        gl.uniform2f(uResolution, canvas.width, canvas.height);
+
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+
         rafRef.current = requestAnimationFrame(renderLoop);
-        return;
-      }
-
-      const time = (performance.now() - startTime) / 1000;
-
-      // Lerp mouse for smoothness
-      lerpMouseRef.current.x += (mouseRef.current.x - lerpMouseRef.current.x) * 0.05;
-      lerpMouseRef.current.y += (mouseRef.current.y - lerpMouseRef.current.y) * 0.05;
-
-      gl.uniform1f(uTime, time);
-      gl.uniform2f(uMouse, lerpMouseRef.current.x, lerpMouseRef.current.y);
-      gl.uniform2f(uResolution, canvas.width, canvas.height);
-
-      gl.drawArrays(gl.TRIANGLES, 0, 6);
-
+      };
       rafRef.current = requestAnimationFrame(renderLoop);
+
+      dispose = () => {
+        cancelAnimationFrame(rafRef.current);
+        window.removeEventListener("resize", resize);
+        document.removeEventListener("visibilitychange", handleVisibility);
+        canvas.removeEventListener("webglcontextlost", handleContextLost);
+        canvas.removeEventListener("webglcontextrestored", handleContextRestored);
+        gl.deleteProgram(program);
+        gl.deleteShader(vs);
+        gl.deleteShader(fs);
+        gl.deleteBuffer(buffer);
+      };
     };
-    rafRef.current = requestAnimationFrame(renderLoop);
+
+    // The canvas is decorative and sits behind the hero text. Starting the
+    // shader compile + render loop on idle keeps the LCP/TBT window clear.
+    const canDefer = typeof window.requestIdleCallback === "function";
+    const requestIdle = canDefer
+      ? window.requestIdleCallback(init, { timeout: 2000 })
+      : window.setTimeout(init, 2000);
 
     return () => {
-      cancelAnimationFrame(rafRef.current);
-      window.removeEventListener("resize", resize);
-      document.removeEventListener("visibilitychange", handleVisibility);
-      canvas.removeEventListener("webglcontextlost", handleContextLost);
-      canvas.removeEventListener("webglcontextrestored", handleContextRestored);
-      gl.deleteProgram(program);
-      gl.deleteShader(vs);
-      gl.deleteShader(fs);
-      gl.deleteBuffer(buffer);
+      cancelled = true;
+      if (canDefer) {
+        window.cancelIdleCallback(requestIdle);
+      } else {
+        window.clearTimeout(requestIdle);
+      }
+      dispose?.();
     };
   }, [reduced]);
 


### PR DESCRIPTION
Closes #35

## Summary
- Reduce JavaScript no crítico en la carga inicial mediante imports diferidos para chat y command palette.
- Retrasa WebGL y videos no críticos fuera de la ventana inicial de LCP/TBT.
- Corrige contraste, nombres accesibles y orden de headings detectados por Lighthouse.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 143 tests
- [x] `pnpm build`
- [x] `pnpm audit --prod`
- [x] `git diff --check`
- [ ] Lighthouse posterior al merge pendiente

## Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers
- [ ] Automated checks pending