### PR TITLE
fix(a11y): improve desktop scene contrast

### DIFF
--- a/src/components/sections/FeaturedWork.test.tsx
+++ b/src/components/sections/FeaturedWork.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, within, cleanup } from "@testing-library/react";
 import FeaturedWork from "./FeaturedWork";
 import type { ProjectItem } from "@/i18n/types";
 
@@ -68,6 +68,7 @@ vi.mock("./Scene", () => ({
   Scene: ({ project }: { project: ProjectItem }) => <h3>{project.title}</h3>,
   getAccent: () => ({ fg: "#6db88a", bg: "#101210", ink: "#ece8e0" }),
   accentAlpha: (_c: string, a: number) => `rgba(0,0,0,${a})`,
+  mutedInk: (ink: string) => `${ink}86`,
 }));
 
 function stubMatchMedia(matches: boolean) {
@@ -122,5 +123,34 @@ describe("FeaturedWork", () => {
     expect(
       h2.compareDocumentPosition(firstH3 as Node) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+  });
+
+  it("renders the cinematic chapter heading at AA-safe muted ink", async () => {
+    stubMatchMedia(true);
+    render(<FeaturedWork />);
+
+    const h2 = await screen.findByRole("heading", { level: 2, name: /Selected work/i });
+    expect(h2.getAttribute("style")).toContain("rgba(236, 232, 224, 0.525)");
+  });
+
+  it("renders the cinematic scroll hint at AA-safe muted ink", async () => {
+    stubMatchMedia(true);
+    render(<FeaturedWork />);
+
+    await screen.findByRole("heading", { level: 2, name: /Selected work/i });
+    const hint = screen.getByText("Scroll for next project");
+    expect(hint.getAttribute("style")).toContain("rgba(236, 232, 224, 0.525)");
+  });
+
+  it("names nav buttons with their full visible label (no aria-label override)", async () => {
+    stubMatchMedia(true);
+    render(<FeaturedWork />);
+
+    const nav = await screen.findByRole("navigation", { name: /Project navigation/i });
+    const button = within(nav).getByRole("button", { name: /01/i });
+    expect(button).not.toHaveAttribute("aria-label");
+    expect(button).toHaveTextContent("01");
+    expect(button).toHaveTextContent("EyeNet");
+    expect(button).toHaveTextContent("Client project");
   });
 });

--- a/src/components/sections/FeaturedWork.tsx
+++ b/src/components/sections/FeaturedWork.tsx
@@ -20,7 +20,7 @@ import {
   getIncomingFadeDelay,
   CHROME_TRANSITION_MS,
 } from "@/lib/featuredWorkScrollConfig";
-import { Scene, getAccent, accentAlpha } from "./Scene";
+import { Scene, getAccent, accentAlpha, mutedInk } from "./Scene";
 
 const ProjectSpotlight = dynamic(
   () => import("../portfolio/ProjectSpotlight"),
@@ -257,14 +257,15 @@ export default function FeaturedWork() {
     const inkLine = `${ink}33`;
 
     if (variant === "cinematic" && sceneIndex !== undefined) {
+      const muted = mutedInk(ink);
       return (
         <header className="pointer-events-auto font-mono text-[9px] font-bold uppercase tracking-[0.32em]">
           {/* Section heading kept as a real h2 so the desktop heading order is h1 → h2 → h3 */}
-          <h2 className="inline font-mono text-[9px] font-bold uppercase tracking-[0.32em]" style={{ color: `${ink}40` }}>
+          <h2 className="inline font-mono text-[9px] font-bold uppercase tracking-[0.32em]" style={{ color: muted }}>
             {t.work.title}
           </h2>
-          <span style={{ color: `${ink}25` }}> · </span>
-          <span style={{ color: `${ink}55` }}>
+          <span aria-hidden="true" style={{ color: `${ink}25` }}> · </span>
+          <span style={{ color: muted }}>
             {String(sceneIndex + 1).padStart(2, "0")}/{String(projects.length).padStart(2, "0")}
           </span>
         </header>
@@ -373,6 +374,7 @@ export default function FeaturedWork() {
                 const projectAccent = getAccent(p.id);
                 const sceneAccent = getAccent(projects[activeScene]?.id ?? "00");
                 const isOn = i === activeScene;
+                const muted = mutedInk(sceneAccent.ink);
                 return (
                   <button
                     key={p.id}
@@ -398,12 +400,11 @@ export default function FeaturedWork() {
                       boxShadow: isOn ? `0 0 0 1px ${accentAlpha(projectAccent.fg, 0.2)}` : undefined,
                     }}
                     aria-current={isOn ? "true" : undefined}
-                    aria-label={`${projectNavLabel(p.title)} — ${p.context}`}
                   >
                     <span
                       className="font-mono text-[9px] font-bold tabular-nums"
                       style={{
-                        color: isOn ? projectAccent.fg : accentAlpha(sceneAccent.ink, 0.5),
+                        color: isOn ? projectAccent.fg : muted,
                       }}
                     >
                       {String(i + 1).padStart(2, "0")}
@@ -417,7 +418,7 @@ export default function FeaturedWork() {
                       </span>
                       <span
                         className="hidden font-mono text-[8px] uppercase tracking-wider sm:block"
-                        style={{ color: accentAlpha(sceneAccent.ink, 0.48) }}
+                        style={{ color: muted }}
                       >
                         {p.context}
                       </span>
@@ -463,7 +464,7 @@ export default function FeaturedWork() {
               <span
                 className="font-mono text-[9px] font-bold uppercase tracking-[0.3em]"
                 style={{
-                  color: `${getAccent(projects[0]?.id ?? "00").ink}50`,
+                  color: mutedInk(getAccent(projects[0]?.id ?? "00").ink),
                   transition: "color 0.6s ease",
                 }}
               >

--- a/src/components/sections/Scene.test.tsx
+++ b/src/components/sections/Scene.test.tsx
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ACCENT,
+  MUTED_INK_ALPHA,
+  SCENE_ACCENTS,
+  mutedInk,
+} from "./Scene";
+
+const WCAG_AA_MIN = 4.5;
+
+function linearize(c: number): number {
+  const s = c / 255;
+  return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+function hexLuminance(hex: string): number {
+  const h = hex.replace("#", "");
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+function oklchToSrgbHex(l: number, c: number, hDeg: number): string {
+  const hue = (hDeg * Math.PI) / 180;
+  const a = c * Math.cos(hue);
+  const b = c * Math.sin(hue);
+  const l_ = l + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = l - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = l - 0.0894841775 * a - 1.291485548 * b;
+  const l3 = l_ ** 3;
+  const m3 = m_ ** 3;
+  const s3 = s_ ** 3;
+  const toSrgb = (x: number) => {
+    const clamped = Math.max(0, Math.min(1, x));
+    const v =
+      clamped <= 0.0031308 ? 12.92 * clamped : 1.055 * clamped ** (1 / 2.4) - 0.055;
+    return Math.round(v * 255)
+      .toString(16)
+      .padStart(2, "0");
+  };
+  const linR = 4.0767416621 * l3 - 3.3077115913 * m3 + 0.2309699292 * s3;
+  const linG = -1.2684380046 * l3 + 2.6097574011 * m3 - 0.3413193965 * s3;
+  const linB = -0.0041960863 * l3 - 0.7034186147 * m3 + 1.707614701 * s3;
+  return `#${toSrgb(linR)}${toSrgb(linG)}${toSrgb(linB)}`;
+}
+
+/** Resolve an accent background (hex or oklch) to an opaque hex. */
+function accentBgHex(bg: string): string {
+  const match = /^oklch\(([\d.]+)%\s+([\d.]+)\s+([\d.]+)\)$/.exec(bg);
+  if (!match) return bg;
+  return oklchToSrgbHex(
+    parseFloat(match[1]) / 100,
+    parseFloat(match[2]),
+    parseFloat(match[3])
+  );
+}
+
+/** Parse "#rrggbb" or "#rrggbbaa" into RGB channels plus alpha. */
+function parseColor(hex: string): { rgb: number[]; alpha: number } {
+  const h = hex.replace("#", "");
+  const alpha = h.length === 8 ? parseInt(h.slice(6, 8), 16) / 255 : 1;
+  const rgb = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16));
+  return { rgb, alpha };
+}
+
+function contrastRatio(a: string, b: string): number {
+  const hi = Math.max(hexLuminance(a), hexLuminance(b));
+  const lo = Math.min(hexLuminance(a), hexLuminance(b));
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Contrast of a semi-transparent fg composed over an opaque bg. */
+function compositeContrast(fg: string, bg: string): number {
+  const { rgb: frgb, alpha } = parseColor(fg);
+  const { rgb: brgb } = parseColor(bg);
+  const blended = frgb
+    .map((f, i) => Math.round(f * alpha + brgb[i] * (1 - alpha)))
+    .map((v) => v.toString(16).padStart(2, "0"))
+    .join("");
+  return contrastRatio(`#${blended}`, bg);
+}
+
+const ACCENTS = [
+  SCENE_ACCENTS["00"],
+  SCENE_ACCENTS["01"],
+  SCENE_ACCENTS["02"],
+  SCENE_ACCENTS["03"],
+  SCENE_ACCENTS["04"],
+  DEFAULT_ACCENT,
+];
+
+describe("mutedInk", () => {
+  it.each(ACCENTS.map((accent) => [accent.bg, accent.ink] as [string, string]))(
+    "clears WCAG AA (>= 4.5:1) for muted ink on background %s",
+    (bg, ink) => {
+      const muted = mutedInk(ink);
+      expect(compositeContrast(muted, accentBgHex(bg))).toBeGreaterThanOrEqual(
+        WCAG_AA_MIN
+      );
+    }
+  );
+
+  it("keeps the hierarchy: muted ink stays quieter than full ink", () => {
+    for (const accent of ACCENTS) {
+      const bg = accentBgHex(accent.bg);
+      expect(compositeContrast(mutedInk(accent.ink), bg)).toBeLessThan(
+        contrastRatio(accent.ink, bg)
+      );
+    }
+  });
+
+  it("applies the per-family minimum alpha suffix", () => {
+    expect(mutedInk("#ece8e0")).toBe(`#ece8e0${MUTED_INK_ALPHA.dark.toLowerCase()}`);
+    expect(mutedInk("#1c1c1e")).toBe(`#1c1c1e${MUTED_INK_ALPHA.light.toLowerCase()}`);
+  });
+});

--- a/src/components/sections/Scene.tsx
+++ b/src/components/sections/Scene.tsx
@@ -71,6 +71,37 @@ export function accentAlpha(color: string, alpha: number): string {
   return color;
 }
 
+/** Relative luminance of a hex color (WCAG 2.x, sRGB → linear). */
+export function hexLuminance(hex: string): number {
+  const match = /^#?([0-9a-f]{6})$/i.exec(hex);
+  if (!match) return 0;
+  const linear = (c: number) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(match[1].slice(i, i + 2), 16));
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+/**
+ * Minimum AA-safe muted alpha suffixes for accent ink on each scene family.
+ * Light ink over dark scene backgrounds (00/01) clears 4.5:1 from ~0.53, dark
+ * ink over light scene backgrounds (02–04) from ~0.63. These hex suffixes land
+ * at ≈4.6–4.9:1 — the lowest alpha that clears WCAG AA on every scene — while
+ * staying visibly quieter than full ink so the primary/secondary hierarchy holds.
+ */
+export const MUTED_INK_ALPHA: Record<"dark" | "light", string> = {
+  dark: "86",
+  light: "A0",
+};
+
+/** Accent ink with the AA-safe muted alpha for its scene background. */
+export function mutedInk(ink: string): string {
+  const alpha =
+    hexLuminance(ink) > 0.5 ? MUTED_INK_ALPHA.dark : MUTED_INK_ALPHA.light;
+  return accentAlpha(ink, parseInt(alpha, 16) / 255);
+}
+
 const VISIBLE_TAGS = 5;
 
 function resolveImageSrc(image: string): string {
@@ -95,6 +126,7 @@ function ProjectEvidence({
   const src = resolveImageSrc(project.image);
   const isExternal = project.href.startsWith("http");
   const usePipelineEvidence = isEyeNetProject(project);
+  const muted = mutedInk(accent.ink);
   const media = registryMedia
     ? { ...registryMedia, alt: project.title }
     : null;
@@ -142,7 +174,7 @@ function ProjectEvidence({
     <figure className="flex flex-col gap-2">
       <figcaption
         className="font-mono text-[9px] font-bold uppercase tracking-[0.28em]"
-        style={{ color: `${accent.ink}45` }}
+        style={{ color: muted }}
       >
         {evidenceLabel}
       </figcaption>
@@ -186,6 +218,7 @@ export function Scene({
   const caseNumber = String(index + 1).padStart(2, "0");
   const visibleTags = project.tags.slice(0, VISIBLE_TAGS);
   const hiddenTagCount = Math.max(0, project.tags.length - VISIBLE_TAGS);
+  const muted = mutedInk(accent.ink);
 
   useEffect(() => {
     if (isActive) setActiveKey((k) => k + 1);
@@ -202,12 +235,12 @@ export function Scene({
           <span style={{ color: accent.fg }}>
             {isEn ? "Case" : "Caso"} {caseNumber}
           </span>
-          <span style={{ color: `${accent.ink}22` }}>·</span>
-          <span style={{ color: `${accent.ink}50` }}>{project.context}</span>
+          <span aria-hidden="true" style={{ color: `${accent.ink}22` }}>·</span>
+          <span style={{ color: muted }}>{project.context}</span>
           {project.date && (
             <>
-              <span style={{ color: `${accent.ink}22` }}>·</span>
-              <span style={{ color: `${accent.ink}40` }}>{project.date}</span>
+              <span aria-hidden="true" style={{ color: `${accent.ink}22` }}>·</span>
+              <span style={{ color: muted }}>{project.date}</span>
             </>
           )}
         </div>
@@ -221,7 +254,7 @@ export function Scene({
           </h3>
           <p
             className="mt-3 max-w-md font-sans text-[15px] leading-relaxed md:text-base"
-            style={{ color: `${accent.ink}62` }}
+            style={{ color: muted }}
           >
             {project.subtitle}
           </p>
@@ -242,7 +275,7 @@ export function Scene({
                 />
                 <span
                   className="font-mono text-[8px] font-bold uppercase leading-tight tracking-wider"
-                  style={{ color: `${accent.ink}45` }}
+                  style={{ color: muted }}
                 >
                   {m.label}
                 </span>
@@ -253,7 +286,7 @@ export function Scene({
 
         <p
           className="max-w-md font-sans text-sm leading-relaxed"
-          style={{ color: `${accent.ink}55` }}
+          style={{ color: muted }}
         >
           {project.role}
         </p>
@@ -264,13 +297,13 @@ export function Scene({
               <span
                 key={tag}
                 className="rounded px-1.5 py-0.5 font-mono text-[8px] font-medium uppercase tracking-wider"
-                style={{ color: `${accent.ink}50`, background: `${accent.ink}05` }}
+                style={{ color: muted, background: `${accent.ink}05` }}
               >
                 {tag}
               </span>
             ))}
             {hiddenTagCount > 0 && (
-              <span className="font-mono text-[8px]" style={{ color: `${accent.ink}35` }}>
+              <span className="font-mono text-[8px]" style={{ color: muted }}>
                 +{hiddenTagCount}
               </span>
             )}
@@ -290,7 +323,7 @@ export function Scene({
             type="button"
             onClick={() => onOpenSpotlight(project)}
             className="font-sans text-xs font-medium underline-offset-4 transition-colors hover:underline"
-            style={{ color: `${accent.ink}45` }}
+            style={{ color: muted }}
           >
             {labels.inspect}
           </button>


### PR DESCRIPTION
Closes #37

## Summary
- Ajusta colores secundarios de escenas al mínimo WCAG AA según el fondo de cada familia visual.
- Elimina nombres accesibles que no coincidían con el texto visible de la navegación de proyectos.
- Añade pruebas de contraste y regresión de accesibilidad.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 154 tests
- [x] `pnpm build`
- [x] `pnpm audit --prod`
- [x] `git diff --check`
- [ ] Lighthouse posterior al merge pendiente

## Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers
- [ ] Automated checks pending