### PR TITLE
fix(a11y): close remaining scene contrast gaps

### DIFF
--- a/src/components/portfolio/viz/eyenetPipelineShared.tsx
+++ b/src/components/portfolio/viz/eyenetPipelineShared.tsx
@@ -298,10 +298,10 @@ export function EyeNetPipelineFlow({
   const pipeline = (
     <>
       <div className="flex items-center justify-between gap-2 px-1">
-        <span className="font-mono text-[8px] uppercase tracking-[0.2em] text-white/35">
+        <span className="font-mono text-[8px] uppercase tracking-[0.2em] text-white/55">
           {isEn ? "Document pipeline" : "Pipeline documental"}
         </span>
-        <span className="flex items-center gap-1.5 font-mono text-[8px] uppercase tracking-widest text-white/25">
+        <span className="flex items-center gap-1.5 font-mono text-[8px] uppercase tracking-widest text-white/50">
           <span
             className="h-1 w-1 rounded-full bg-emerald-400"
             style={reduced ? undefined : { animation: "pulse 2s ease-in-out infinite" }}

--- a/src/components/sections/FeaturedWork.test.tsx
+++ b/src/components/sections/FeaturedWork.test.tsx
@@ -68,7 +68,7 @@ vi.mock("./Scene", () => ({
   Scene: ({ project }: { project: ProjectItem }) => <h3>{project.title}</h3>,
   getAccent: () => ({ fg: "#6db88a", bg: "#101210", ink: "#ece8e0" }),
   accentAlpha: (_c: string, a: number) => `rgba(0,0,0,${a})`,
-  mutedInk: (ink: string) => `${ink}86`,
+  mutedInk: (ink: string) => `${ink}92`,
 }));
 
 function stubMatchMedia(matches: boolean) {
@@ -130,7 +130,7 @@ describe("FeaturedWork", () => {
     render(<FeaturedWork />);
 
     const h2 = await screen.findByRole("heading", { level: 2, name: /Selected work/i });
-    expect(h2.getAttribute("style")).toContain("rgba(236, 232, 224, 0.525)");
+    expect(h2.getAttribute("style")).toContain("rgba(236, 232, 224, 0.573)");
   });
 
   it("renders the cinematic scroll hint at AA-safe muted ink", async () => {
@@ -139,7 +139,7 @@ describe("FeaturedWork", () => {
 
     await screen.findByRole("heading", { level: 2, name: /Selected work/i });
     const hint = screen.getByText("Scroll for next project");
-    expect(hint.getAttribute("style")).toContain("rgba(236, 232, 224, 0.525)");
+    expect(hint.getAttribute("style")).toContain("rgba(236, 232, 224, 0.573)");
   });
 
   it("names nav buttons with their full visible label (no aria-label override)", async () => {

--- a/src/components/sections/Scene.test.tsx
+++ b/src/components/sections/Scene.test.tsx
@@ -112,4 +112,30 @@ describe("mutedInk", () => {
     expect(mutedInk("#ece8e0")).toBe(`#ece8e0${MUTED_INK_ALPHA.dark.toLowerCase()}`);
     expect(mutedInk("#1c1c1e")).toBe(`#1c1c1e${MUTED_INK_ALPHA.light.toLowerCase()}`);
   });
+
+  it("keeps dark-scene muted ink AA-safe on the desktop cross-fade blend (Lighthouse 4.39)", () => {
+    const muted = mutedInk("#ece8e0");
+    const blendedBg = "#27292c";
+    expect(compositeContrast(muted, blendedBg)).toBeGreaterThanOrEqual(
+      WCAG_AA_MIN
+    );
+  });
+});
+
+describe("EyeNet pipeline header contrast on the #0d1117 evidence frame", () => {
+  const frameBg = "#0d1117";
+
+  it("keeps the 'Document pipeline' label (text-white/55) AA-safe", () => {
+    const label = "#ffffff8c";
+    expect(compositeContrast(label, frameBg)).toBeGreaterThanOrEqual(
+      WCAG_AA_MIN
+    );
+  });
+
+  it("keeps the 'LIVE · 5 nodes' badge (text-white/50) AA-safe", () => {
+    const badge = "#ffffff80";
+    expect(compositeContrast(badge, frameBg)).toBeGreaterThanOrEqual(
+      WCAG_AA_MIN
+    );
+  });
 });

--- a/src/components/sections/Scene.tsx
+++ b/src/components/sections/Scene.tsx
@@ -86,12 +86,14 @@ export function hexLuminance(hex: string): number {
 /**
  * Minimum AA-safe muted alpha suffixes for accent ink on each scene family.
  * Light ink over dark scene backgrounds (00/01) clears 4.5:1 from ~0.53, dark
- * ink over light scene backgrounds (02–04) from ~0.63. These hex suffixes land
- * at ≈4.6–4.9:1 — the lowest alpha that clears WCAG AA on every scene — while
- * staying visibly quieter than full ink so the primary/secondary hierarchy holds.
+ * ink over light scene backgrounds (02–04) from ~0.63. The dark suffix was
+ * raised from 86 to 92 after Lighthouse measured 4.39:1 on desktop during the
+ * scene cross-fade (bg blends to ≈#27292c); 92 lands at ≈4.9:1 even on that
+ * blended background while staying visibly quieter than full ink so the
+ * primary/secondary hierarchy holds.
  */
 export const MUTED_INK_ALPHA: Record<"dark" | "light", string> = {
-  dark: "86",
+  dark: "92",
   light: "A0",
 };
 


### PR DESCRIPTION
Closes #39

## Summary
- Eleva los tres textos de escenas que estaban por debajo de 4.5:1.
- Mantiene layout, copy y jerarquía visual.
- Añade regresiones de contraste para escenas y pipeline EyeNet.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 157 tests
- [x] `pnpm build`
- [x] `pnpm audit --prod`
- [x] `git diff --check`
- [ ] Lighthouse posterior al merge pendiente

## Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers
- [ ] Automated checks pending