### PR TITLE
perf(mobile): pause decorative animation loops

### DIFF
--- a/src/components/ui/Marquee.test.tsx
+++ b/src/components/ui/Marquee.test.tsx
@@ -1,10 +1,10 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
+import gsap from "gsap";
 import Marquee from "./Marquee";
 
-afterEach(() => {
-  cleanup();
-});
+const useReducedMotionMock = vi.fn(() => false);
+const useCoarsePointerMock = vi.fn(() => false);
 
 vi.mock("gsap", () => ({
   default: {
@@ -14,7 +14,11 @@ vi.mock("gsap", () => ({
 }));
 
 vi.mock("@/hooks/useReducedMotion", () => ({
-  useReducedMotion: () => true,
+  useReducedMotion: () => useReducedMotionMock(),
+}));
+
+vi.mock("@/hooks/useCoarsePointer", () => ({
+  useCoarsePointer: () => useCoarsePointerMock(),
 }));
 
 vi.mock("@/i18n/LanguageContext", () => ({
@@ -32,6 +36,16 @@ vi.mock("@/i18n/LanguageContext", () => ({
 }));
 
 describe("Marquee", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    useReducedMotionMock.mockReturnValue(false);
+    useCoarsePointerMock.mockReturnValue(false);
+    cleanup();
+  });
+
   it("renders neutral segments at AA-safe opacity", () => {
     render(<Marquee />);
     const neutral = screen.getAllByText("Machine Learning");
@@ -52,5 +66,32 @@ describe("Marquee", () => {
   it("exposes an accessible name", () => {
     render(<Marquee />);
     expect(screen.getByRole("marquee")).toHaveAttribute("aria-label", "Tech marquee");
+  });
+
+  it("starts the loop tween on desktop", () => {
+    useReducedMotionMock.mockReturnValue(false);
+    useCoarsePointerMock.mockReturnValue(false);
+
+    render(<Marquee />);
+    expect(gsap.to).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ repeat: -1, xPercent: -50 })
+    );
+  });
+
+  it("does not start the loop tween on mobile viewport", () => {
+    useReducedMotionMock.mockReturnValue(false);
+    useCoarsePointerMock.mockReturnValue(true);
+
+    render(<Marquee />);
+    expect(gsap.to).not.toHaveBeenCalled();
+  });
+
+  it("does not start the loop tween under reduced motion", () => {
+    useReducedMotionMock.mockReturnValue(true);
+    useCoarsePointerMock.mockReturnValue(false);
+
+    render(<Marquee />);
+    expect(gsap.to).not.toHaveBeenCalled();
   });
 });

--- a/src/components/ui/Marquee.tsx
+++ b/src/components/ui/Marquee.tsx
@@ -4,16 +4,18 @@ import { useRef, useEffect } from "react";
 import gsap from "gsap";
 import { useLanguage } from "@/i18n/LanguageContext";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { useCoarsePointer } from "@/hooks/useCoarsePointer";
 
 export default function Marquee() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const tweenRef = useRef<gsap.core.Tween | null>(null);
   const { t } = useLanguage();
   const reduced = useReducedMotion();
+  const coarse = useCoarsePointer();
   const segments = t.marquee.segments;
 
   useEffect(() => {
-    if (!scrollRef.current || reduced) return;
+    if (!scrollRef.current || reduced || coarse) return;
     const el = scrollRef.current;
 
     tweenRef.current = gsap.to(el, {
@@ -26,7 +28,7 @@ export default function Marquee() {
     return () => {
       tweenRef.current?.kill();
     };
-  }, [reduced]);
+  }, [reduced, coarse]);
 
   const setSpeed = (scale: number) => {
     if (tweenRef.current) {

--- a/src/components/ui/WebGLHeroCanvas.test.tsx
+++ b/src/components/ui/WebGLHeroCanvas.test.tsx
@@ -6,7 +6,14 @@ vi.mock("@/hooks/useReducedMotion", () => ({
   useReducedMotion: () => false,
 }));
 
+const useCoarsePointerMock = vi.fn(() => false);
+
+vi.mock("@/hooks/useCoarsePointer", () => ({
+  useCoarsePointer: () => useCoarsePointerMock(),
+}));
+
 afterEach(() => {
+  useCoarsePointerMock.mockReturnValue(false);
   cleanup();
 });
 
@@ -41,5 +48,24 @@ describe("WebGLHeroCanvas", () => {
     expect(fallback).toBeInTheDocument();
 
     vi.doUnmock("@/hooks/useReducedMotion");
+  });
+
+  it("skips the canvas and shows the CSS fallback on mobile viewport", () => {
+    useCoarsePointerMock.mockReturnValue(true);
+    const getContext = vi.fn();
+    HTMLCanvasElement.prototype.getContext = getContext;
+
+    const { container } = render(<WebGLHeroCanvas />);
+    expect(container.querySelector("canvas")).not.toBeInTheDocument();
+    expect(container.querySelector("[data-webgl-fallback]")).toBeInTheDocument();
+    expect(getContext).not.toHaveBeenCalled();
+  });
+
+  it("still renders the canvas on desktop viewport", () => {
+    useCoarsePointerMock.mockReturnValue(false);
+    HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue(null);
+
+    render(<WebGLHeroCanvas />);
+    expect(document.querySelector("canvas")).toBeInTheDocument();
   });
 });

--- a/src/components/ui/WebGLHeroCanvas.tsx
+++ b/src/components/ui/WebGLHeroCanvas.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useCallback } from "react";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { useCoarsePointer } from "@/hooks/useCoarsePointer";
 
 const VERTEX_SHADER = `
   attribute vec2 a_position;
@@ -111,6 +112,7 @@ function createProgram(gl: WebGLRenderingContext, vs: WebGLShader, fs: WebGLShad
 export default function WebGLHeroCanvas({ className }: { className?: string }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const reduced = useReducedMotion();
+  const coarse = useCoarsePointer();
   const rafRef = useRef<number>(0);
   const mouseRef = useRef({ x: 0.5, y: 0.5 });
   const lerpMouseRef = useRef({ x: 0.5, y: 0.5 });
@@ -124,7 +126,7 @@ export default function WebGLHeroCanvas({ className }: { className?: string }) {
   }, []);
 
   useEffect(() => {
-    if (reduced) return;
+    if (reduced || coarse) return;
 
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -250,9 +252,9 @@ export default function WebGLHeroCanvas({ className }: { className?: string }) {
       }
       dispose?.();
     };
-  }, [reduced]);
+  }, [reduced, coarse]);
 
-  if (reduced) {
+  if (reduced || coarse) {
     return (
       <div
         data-webgl-fallback

--- a/src/hooks/useCoarsePointer.test.ts
+++ b/src/hooks/useCoarsePointer.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCoarsePointer } from "./useCoarsePointer";
+
+interface MqlChangeEvent {
+  matches: boolean;
+}
+
+function stubMatchMedia(matches: boolean) {
+  const listeners: Array<(e: MqlChangeEvent) => void> = [];
+  const matchMediaMock = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: (_type: string, cb: (e: MqlChangeEvent) => void) => {
+      listeners.push(cb);
+    },
+    removeEventListener: () => {},
+    dispatchEvent: () => {},
+  }));
+  window.matchMedia = matchMediaMock;
+  return { matchMediaMock, listeners };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useCoarsePointer", () => {
+  it("is false on desktop / fine-pointer viewports", () => {
+    stubMatchMedia(false);
+    const { result } = renderHook(() => useCoarsePointer());
+    expect(result.current).toBe(false);
+  });
+
+  it("is true on mobile / coarse-pointer viewports", () => {
+    stubMatchMedia(true);
+    const { result } = renderHook(() => useCoarsePointer());
+    expect(result.current).toBe(true);
+  });
+
+  it("targets the mobile budget media query", () => {
+    const { matchMediaMock } = stubMatchMedia(false);
+    renderHook(() => useCoarsePointer());
+    const query = matchMediaMock.mock.calls[0][0] as string;
+    expect(query).toMatch(/hover: none/);
+    expect(query).toMatch(/max-width: 767px/);
+  });
+
+  it("reacts to media query changes", () => {
+    const { listeners } = stubMatchMedia(false);
+    const { result } = renderHook(() => useCoarsePointer());
+    expect(result.current).toBe(false);
+
+    act(() => listeners[0]?.({ matches: true }));
+    expect(result.current).toBe(true);
+
+    act(() => listeners[0]?.({ matches: false }));
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/useCoarsePointer.ts
+++ b/src/hooks/useCoarsePointer.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const MOBILE_BUDGET_MQ = "(hover: none), (max-width: 767px)";
+
+export function useCoarsePointer(): boolean {
+  const [coarse, setCoarse] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_BUDGET_MQ);
+    setCoarse(mql.matches);
+
+    const handler = (e: MediaQueryListEvent) => setCoarse(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return coarse;
+}


### PR DESCRIPTION
Closes #41

## Summary
- Evita compilar WebGL y ejecutar su loop `requestAnimationFrame` en móvil/coarse pointer.
- Mantiene la marquee estática en móvil y conserva animaciones desktop.
- Añade hook y pruebas para el presupuesto de animación móvil.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 166 tests
- [x] `pnpm build`
- [x] `pnpm audit --prod`
- [x] `git diff --check`
- [ ] Lighthouse posterior al merge pendiente

## Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers
- [ ] Automated checks pending