### PR TITLE
perf(mobile): reveal hero content on first paint

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -194,6 +194,22 @@ html.no-transition * {
   background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
 }
 
+/* ─── Hero critical text — paint first, animate after ───
+   The hero copy must be visible in the initial HTML so mobile LCP can
+   fire at first contentful paint. The entrance animation (gsap) only
+   applies on fine-pointer desktop, where the text is kept hidden until
+   the reveal so there is no flash. Mirrors useCoarsePointer's query:
+   coarse = (hover: none) or (max-width: 767px). */
+.hero-reveal {
+  opacity: 1;
+}
+
+@media (hover: hover) and (min-width: 768px) {
+  .hero-reveal {
+    opacity: 0;
+  }
+}
+
 /* ─── Warm accent underline — for editorial emphasis ─── */
 .accent-underline {
   text-decoration-line: underline;

--- a/src/components/sections/Hero.test.tsx
+++ b/src/components/sections/Hero.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import gsap from "gsap";
+import Hero from "./Hero";
+
+const useReducedMotionMock = vi.fn(() => false);
+const useCoarsePointerMock = vi.fn(() => false);
+
+vi.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: () => {
+    const WebGLHeroCanvasStub = () => <div data-testid="webgl-hero-stub" aria-hidden="true" />;
+    WebGLHeroCanvasStub.displayName = "WebGLHeroCanvasStub";
+    return WebGLHeroCanvasStub;
+  },
+}));
+
+vi.mock("gsap", () => ({
+  default: {
+    context: vi.fn().mockImplementation((cb: () => void) => {
+      cb();
+      return { revert: vi.fn() };
+    }),
+    set: vi.fn(),
+    fromTo: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/useReducedMotion", () => ({
+  useReducedMotion: () => useReducedMotionMock(),
+}));
+
+vi.mock("@/hooks/useCoarsePointer", () => ({
+  useCoarsePointer: () => useCoarsePointerMock(),
+}));
+
+vi.mock("@/i18n/LanguageContext", () => ({
+  useLanguage: () => ({
+    t: {
+      hero: {
+        eyebrow: "AI & Data Engineer",
+        title1: "Production ML systems",
+        title2: "and AI automation.",
+        subtitle: "I build infrastructure that ships.",
+        focusLine: "Client work · research",
+        cta: "View case studies",
+        downloadCv: "Download CV",
+        scrollHint: "Scroll to featured work",
+      },
+    },
+  }),
+}));
+
+describe("Hero", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    useReducedMotionMock.mockReturnValue(false);
+    useCoarsePointerMock.mockReturnValue(false);
+    cleanup();
+  });
+
+  it("keeps hero text visible on mobile (no inline hidden state in the LCP element)", () => {
+    useCoarsePointerMock.mockReturnValue(true);
+    const { container } = render(<Hero />);
+
+    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+
+    const reveals = container.querySelectorAll(".hero-reveal");
+    expect(reveals.length).toBe(7);
+    for (const el of reveals) {
+      expect((el.getAttribute("style") ?? "").toLowerCase()).not.toContain("opacity");
+    }
+  });
+
+  it("does not start the entrance animation on mobile viewport", () => {
+    useCoarsePointerMock.mockReturnValue(true);
+    render(<Hero />);
+
+    expect(gsap.fromTo).not.toHaveBeenCalled();
+    expect(gsap.set).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ opacity: 1, y: 0 })
+    );
+  });
+
+  it("runs the entrance animation on desktop fine-pointer viewports", () => {
+    useCoarsePointerMock.mockReturnValue(false);
+    useReducedMotionMock.mockReturnValue(false);
+    render(<Hero />);
+
+    expect(gsap.fromTo).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ opacity: 0, y: 20 }),
+      expect.objectContaining({ opacity: 1, duration: 0.9 })
+    );
+  });
+
+  it("reveals text immediately under reduced motion without animating", () => {
+    useReducedMotionMock.mockReturnValue(true);
+    useCoarsePointerMock.mockReturnValue(false);
+    render(<Hero />);
+
+    expect(gsap.fromTo).not.toHaveBeenCalled();
+    expect(gsap.set).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ opacity: 1, y: 0 })
+    );
+  });
+
+  it("keeps the decorative background fallback in the DOM", () => {
+    useCoarsePointerMock.mockReturnValue(true);
+    render(<Hero />);
+
+    expect(screen.getByTestId("webgl-hero-stub")).toBeInTheDocument();
+  });
+});

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import gsap from "gsap";
 import { useLanguage } from "@/i18n/LanguageContext";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
+import { useCoarsePointer } from "@/hooks/useCoarsePointer";
 import { ArrowDownToLine, ArrowUpRight } from "lucide-react";
 import Link from "next/link";
 
@@ -25,6 +26,7 @@ export default function Hero() {
   const { t } = useLanguage();
   const labels = t.hero;
   const reduced = useReducedMotion();
+  const coarse = useCoarsePointer();
 
   useEffect(() => {
     const ctx = gsap.context(() => {
@@ -38,7 +40,7 @@ export default function Hero() {
         scrollHintRef.current,
       ].filter(Boolean);
 
-      if (reduced) {
+      if (reduced || coarse) {
         gsap.set(targets, { opacity: 1, y: 0 });
         return;
       }
@@ -58,7 +60,7 @@ export default function Hero() {
     }, container);
 
     return () => ctx.revert();
-  }, [reduced]);
+  }, [reduced, coarse]);
 
   return (
     <section
@@ -76,8 +78,7 @@ export default function Hero() {
       <div className="relative z-10 max-w-3xl">
         <p
           ref={eyebrowRef}
-          className="mb-5 font-mono text-[10px] font-bold uppercase tracking-[0.32em] text-offwhite/45"
-          style={{ opacity: reduced ? 1 : 0 }}
+          className="hero-reveal mb-5 font-mono text-[10px] font-bold uppercase tracking-[0.32em] text-offwhite/45"
         >
           {labels.eyebrow}
         </p>
@@ -86,13 +87,12 @@ export default function Hero() {
           className="font-sans font-medium tracking-tight text-offwhite leading-[1.04]"
           style={{ fontSize: "clamp(2.35rem, 5.5vw, 4.5rem)", textWrap: "balance" }}
         >
-          <span ref={line1Ref} className="block" style={{ opacity: reduced ? 1 : 0 }}>
+          <span ref={line1Ref} className="hero-reveal block">
             {labels.title1}
           </span>
           <span
             ref={line2Ref}
-            className="mt-1 block font-display italic text-offwhite/72"
-            style={{ opacity: reduced ? 1 : 0 }}
+            className="hero-reveal mt-1 block font-display italic text-offwhite/72"
           >
             {labels.title2}
           </span>
@@ -100,24 +100,21 @@ export default function Hero() {
 
         <p
           ref={sublineRef}
-          className="mt-6 max-w-xl font-sans text-base leading-relaxed text-offwhite/58 md:mt-8 md:text-[17px]"
-          style={{ opacity: reduced ? 1 : 0 }}
+          className="hero-reveal mt-6 max-w-xl font-sans text-base leading-relaxed text-offwhite/58 md:mt-8 md:text-[17px]"
         >
           {labels.subtitle}
         </p>
 
         <p
           ref={focusRef}
-          className="mt-4 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/35"
-          style={{ opacity: reduced ? 1 : 0 }}
+          className="hero-reveal mt-4 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/35"
         >
           {labels.focusLine}
         </p>
 
         <div
           ref={actionRef}
-          className="mt-10 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center md:mt-12"
-          style={{ opacity: reduced ? 1 : 0 }}
+          className="hero-reveal mt-10 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center md:mt-12"
         >
           <Link
             href="#projects"
@@ -140,8 +137,7 @@ export default function Hero() {
       <a
         ref={scrollHintRef}
         href="#projects"
-        className="relative z-10 mt-14 flex flex-col items-start gap-2 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/30 transition-colors hover:text-offwhite/50 md:mt-16"
-        style={{ opacity: reduced ? 1 : 0 }}
+        className="hero-reveal relative z-10 mt-14 flex flex-col items-start gap-2 font-mono text-[9px] font-bold uppercase tracking-[0.28em] text-offwhite/30 transition-colors hover:text-offwhite/50 md:mt-16"
       >
         <span>{labels.scrollHint}</span>
         <span className="h-8 w-px bg-offwhite/20" aria-hidden="true" />

--- a/src/hooks/useCoarsePointer.test.ts
+++ b/src/hooks/useCoarsePointer.test.ts
@@ -60,4 +60,18 @@ describe("useCoarsePointer", () => {
     act(() => listeners[0]?.({ matches: false }));
     expect(result.current).toBe(false);
   });
+
+  it("reads the coarse state synchronously on mount (no effect round-trip)", () => {
+    const { matchMediaMock } = stubMatchMedia(true);
+    const { result } = renderHook(() => useCoarsePointer());
+    expect(result.current).toBe(true);
+    expect(matchMediaMock).toHaveBeenCalled();
+  });
+
+  it("resolves to false synchronously on desktop viewports", () => {
+    const { matchMediaMock } = stubMatchMedia(false);
+    const { result } = renderHook(() => useCoarsePointer());
+    expect(result.current).toBe(false);
+    expect(matchMediaMock).toHaveBeenCalled();
+  });
 });

--- a/src/hooks/useCoarsePointer.ts
+++ b/src/hooks/useCoarsePointer.ts
@@ -5,7 +5,14 @@ import { useEffect, useState } from "react";
 const MOBILE_BUDGET_MQ = "(hover: none), (max-width: 767px)";
 
 export function useCoarsePointer(): boolean {
-  const [coarse, setCoarse] = useState(false);
+  const [coarse, setCoarse] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.matchMedia(MOBILE_BUDGET_MQ).matches;
+    } catch {
+      return false;
+    }
+  });
 
   useEffect(() => {
     const mql = window.matchMedia(MOBILE_BUDGET_MQ);


### PR DESCRIPTION
Closes #43

## Summary
- Hace visible el contenido textual del hero móvil desde el primer paint.
- Mantiene la animación GSAP para desktop con fine pointer.
- Evita flicker mediante inicialización síncrona de coarse-pointer y añade pruebas.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 173 tests
- [x] `pnpm build`
- [x] `pnpm audit --prod`
- [x] `git diff --check`
- [ ] Lighthouse posterior al merge pendiente

## Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit
- [x] No `Co-Authored-By` trailers
- [ ] Automated checks pending